### PR TITLE
Fiddling with basic-cli-commands branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-formica
-formicactl/formicactl
+formicactl
 .gobuild/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_install:
 
 script:
 - make lint
-- make ci-build
 - make ci-test
-- ./formicactl/formicactl
+- make ci-build
+- ./formicactl

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ COMMIT := $(shell git rev-parse --short HEAD)
 
 SOURCE=$(shell find . -name '*.go')
 
-BUILD_COMMAND=go build -o formicactl/$(BIN) github.com/giantswarm/formica/$(BIN)
+BUILD_COMMAND=go build -o $(BIN)
 TEST_COMMAND=go test ./... -cover
 
-all: formica/$(BIN)
+all: $(BIN)
 
 clean:
-	rm -rf $(BUILD_PATH) formicactl/$(BIN)
+	rm -rf $(BUILD_PATH) $(BIN)
 
 .gobuild:
 	@mkdir -p $(GS_PATH)
@@ -34,7 +34,7 @@ clean:
 deps:
 	@${MAKE} -B -s .gobuild
 
-formica/$(BIN): $(SOURCE) VERSION .gobuild
+$(BIN): $(SOURCE) VERSION .gobuild
 	@echo Building inside Docker container for $(GOOS)/$(GOARCH)
 	docker run \
 	    --rm \
@@ -46,8 +46,8 @@ formica/$(BIN): $(SOURCE) VERSION .gobuild
 	    golang:1.5 \
 	    $(BUILD_COMMAND)
 
-test:
-	echo Testing inside Docker container for $(GOOS)/$(GOARCH)
+test: $(SOURCE) VERSION .gobuild
+	@echo Testing inside Docker container for $(GOOS)/$(GOARCH)
 	docker run \
 	    --rm \
 	    -v $(shell pwd):/usr/code \
@@ -65,6 +65,6 @@ ci-build: $(SOURCE) VERSION .gobuild
 	echo Building for $(GOOS)/$(GOARCH)
 	$(BUILD_COMMAND)
 
-ci-test:
+ci-test: $(SOURCE) VERSION .gobuild
 	echo Testing for $(GOOS)/$(GOARCH)
 	$(TEST_COMMAND)

--- a/cli/create.go
+++ b/cli/create.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"os"

--- a/cli/formicactl.go
+++ b/cli/formicactl.go
@@ -1,6 +1,6 @@
 // Package formicactl implements a command line client for formica. Cobra CLI
 // is used as framework.
-package main
+package cli
 
 import (
 	"net/url"
@@ -19,7 +19,7 @@ var (
 	newController controller.Controller
 	newFleet      fleet.Fleet
 
-	mainCmd = &cobra.Command{
+	MainCmd = &cobra.Command{
 		Use:   "formicactl",
 		Short: "orchestrate groups of unit files on Fleet clusters",
 		Long:  "orchestrate groups of unit files on Fleet clusters",
@@ -48,16 +48,12 @@ var (
 )
 
 func init() {
-	mainCmd.PersistentFlags().StringVar(&globalFlags.FleetEndpoint, "fleet-endpoint", "file:///var/run/fleet.sock", "endpoint used to connect to fleet")
+	MainCmd.PersistentFlags().StringVar(&globalFlags.FleetEndpoint, "fleet-endpoint", "file:///var/run/fleet.sock", "endpoint used to connect to fleet")
+
+	MainCmd.AddCommand(createCmd)
+	MainCmd.AddCommand(statusCmd)
 }
 
 func mainRun(cmd *cobra.Command, args []string) {
 	cmd.Help()
-}
-
-func main() {
-	mainCmd.AddCommand(createCmd)
-	mainCmd.AddCommand(statusCmd)
-
-	mainCmd.Execute()
 }

--- a/cli/status.go
+++ b/cli/status.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"

--- a/formica.go
+++ b/formica.go
@@ -1,3 +1,0 @@
-package main
-
-func main() {}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/giantswarm/formica/cli"
+)
+
+func main() {
+	if err := cli.MainCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}


### PR DESCRIPTION
I've done a few things here:
- Modified Makefile to build `formicactl` only. We're only building one binary, and I don't like sticking it in a directory. Let's keep things simple.
- Fixed up requirements for some targets - this basically means we don't have to worry about building before testing on travis.
- Moved `formicactl` package to `cli` - largely clerical, I want the binary to be called `formicactl`, and I think `cli` as a package name is somewhat more common.
- `formica.go` to `main.go` - felt weird having it called `formica.go` if we're building `formicactl`, but also felt weird calling it `formicactl.go` if the repository is called `formica`. Very close to golfing.
