### PR TITLE
Fix go vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,9 @@ test: $(SOURCE) VERSION .gobuild
 	    $(TEST_COMMAND)
 
 lint:
-	go vet -x
+	for source_file in $(SOURCE); do \
+		go vet -x $$source_file ; \
+	done
 
 ci-build: $(SOURCE) VERSION .gobuild
 	echo Building for $(GOOS)/$(GOARCH)


### PR DESCRIPTION
This actually runs go vet over all source files.

Note: It won't pick up missing godoc - go lint can do this, but it has way too many false positives to be part of the build process, we're going to have to keep an eye on documentation.
