### PR TITLE
fleet: Added fleet-client mock and simple

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean:
 	@builder get dep -b 65a708cee0a4424f4e353d031ce440643e312f92 https://github.com/spf13/cobra.git $(GOPATH)/src/github.com/spf13/cobra
 	@builder get dep -b 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7 https://github.com/spf13/pflag.git $(GOPATH)/src/github.com/spf13/pflag
 
+	@builder get dep https://github.com/onsi/gomega.git $(GOPATH)/src/github.com/onsi/gomega
 deps:
 	@${MAKE} -B -s .gobuild
 

--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -14,6 +14,12 @@ import (
 	"github.com/coreos/fleet/unit"
 )
 
+const (
+	unitStateInactive = "inactive"
+	unitStateLoaded   = "loaded"
+	unitStateLaunched = "launched"
+)
+
 // Config provides all necessary and injectable configurations for a new
 // fleet client.
 type Config struct {
@@ -174,7 +180,7 @@ func (f fleet) Submit(name, content string) error {
 }
 
 func (f fleet) Start(name string) error {
-	err := f.Client.SetUnitTargetState(name, "launched")
+	err := f.Client.SetUnitTargetState(name, unitStateLaunched)
 	if err != nil {
 		return maskAny(err)
 	}
@@ -183,7 +189,7 @@ func (f fleet) Start(name string) error {
 }
 
 func (f fleet) Stop(name string) error {
-	err := f.Client.SetUnitTargetState(name, "loaded")
+	err := f.Client.SetUnitTargetState(name, unitStateLoaded)
 	if err != nil {
 		return maskAny(err)
 	}
@@ -192,7 +198,7 @@ func (f fleet) Stop(name string) error {
 }
 
 func (f fleet) Destroy(name string) error {
-	err := f.Client.SetUnitTargetState(name, "inactive")
+	err := f.Client.SetUnitTargetState(name, unitStateInactive)
 	if err != nil {
 		return maskAny(err)
 	}

--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -198,7 +198,7 @@ func (f fleet) Stop(name string) error {
 }
 
 func (f fleet) Destroy(name string) error {
-	err := f.Client.SetUnitTargetState(name, unitStateInactive)
+	err := f.Client.DestroyUnit(name)
 	if err != nil {
 		return maskAny(err)
 	}

--- a/fleet/fleet_client_mock_test.go
+++ b/fleet/fleet_client_mock_test.go
@@ -19,6 +19,10 @@ type mockCall struct {
 	Args []interface{}
 }
 
+// containCall returns a new GomegaMatcher to test if a given call was made.
+//
+//     Expect(callRecorderObj).To(containCall("functionName", arg1, arg2))
+//
 func containCall(name string, args ...interface{}) types.GomegaMatcher {
 	return &containsCallMatcher{mockCall{
 		name, args,

--- a/fleet/fleet_client_mock_test.go
+++ b/fleet/fleet_client_mock_test.go
@@ -1,0 +1,86 @@
+package fleet
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/coreos/fleet/machine"
+	"github.com/coreos/fleet/schema"
+	"github.com/onsi/gomega/types"
+)
+
+// callRecorder returns the recorded calls
+type callRecorder interface {
+	Calls() []mockCall
+}
+
+type mockCall struct {
+	Name string
+	Args []interface{}
+}
+
+func containCall(name string, args ...interface{}) types.GomegaMatcher {
+	return &containsCallMatcher{mockCall{
+		name, args,
+	}}
+}
+
+type containsCallMatcher struct {
+	expectedCall mockCall
+}
+
+func (matcher *containsCallMatcher) Match(actual interface{}) (success bool, err error) {
+	client := actual.(callRecorder)
+
+	for _, call := range client.Calls() {
+		if reflect.DeepEqual(matcher.expectedCall, call) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+func (matcher *containsCallMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nto contain call\n\t%#v", actual, matcher.expectedCall)
+}
+func (matcher *containsCallMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("Expected\n\t%#v\nnot to contain call\n\t%#v", actual, matcher.expectedCall)
+}
+
+type fleetClientMock struct {
+	calls []mockCall
+}
+
+func (fleet *fleetClientMock) Calls() []mockCall {
+	return fleet.calls
+}
+
+func (fleet *fleetClientMock) Machines() ([]machine.MachineState, error) {
+	fleet.calls = append(fleet.calls, mockCall{"Machines", []interface{}{}})
+	return nil, nil
+}
+
+func (fleet *fleetClientMock) Unit(unit string) (*schema.Unit, error) {
+	fleet.calls = append(fleet.calls, mockCall{"Unit", []interface{}{unit}})
+	return nil, nil
+}
+func (fleet *fleetClientMock) Units() ([]*schema.Unit, error) {
+	fleet.calls = append(fleet.calls, mockCall{"Units", []interface{}{}})
+	return nil, nil
+}
+func (fleet *fleetClientMock) UnitStates() ([]*schema.UnitState, error) {
+	fleet.calls = append(fleet.calls, mockCall{"UnitStates", []interface{}{}})
+	return nil, nil
+}
+
+func (fleet *fleetClientMock) SetUnitTargetState(name, target string) error {
+	fleet.calls = append(fleet.calls, mockCall{"SetUnitTargetState", []interface{}{name, target}})
+	return nil
+}
+func (fleet *fleetClientMock) CreateUnit(unit *schema.Unit) error {
+	fleet.calls = append(fleet.calls, mockCall{"CreateUnit", []interface{}{unit}})
+	return nil
+}
+func (fleet *fleetClientMock) DestroyUnit(unit string) error {
+	fleet.calls = append(fleet.calls, mockCall{"DestroyUnit", []interface{}{unit}})
+	return nil
+}

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -1,0 +1,35 @@
+package fleet
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestDefaultConfig verifies that the default config contains a basic valid fleet config
+func TestDefaultConfig(t *testing.T) {
+	RegisterTestingT(t)
+
+	cfg := DefaultConfig()
+
+	Expect(cfg.Endpoint).To(Not(BeZero()))
+	Expect(cfg.Client).To(Not(BeZero()))
+}
+
+func GivenMockedFleet() (*fleetClientMock, *fleet) {
+	mock := &fleetClientMock{}
+	return mock, &fleet{
+		Client: mock,
+		Config: DefaultConfig(),
+	}
+}
+
+func TestFleetSubmit(t *testing.T) {
+	RegisterTestingT(t)
+
+	mock, fleet := GivenMockedFleet()
+	err := fleet.Start("unit.service")
+
+	Expect(err).To(Not(HaveOccurred()))
+	Expect(mock).To(containCall("SetUnitTargetState", "unit.service", unitStateLaunched))
+}

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -24,7 +24,7 @@ func GivenMockedFleet() (*fleetClientMock, *fleet) {
 	}
 }
 
-func TestFleetSubmit(t *testing.T) {
+func TestFleetStart_Success(t *testing.T) {
 	RegisterTestingT(t)
 
 	mock, fleet := GivenMockedFleet()
@@ -32,4 +32,24 @@ func TestFleetSubmit(t *testing.T) {
 
 	Expect(err).To(Not(HaveOccurred()))
 	Expect(mock).To(containCall("SetUnitTargetState", "unit.service", unitStateLaunched))
+}
+
+func TestFleetStop_Success(t *testing.T) {
+	RegisterTestingT(t)
+
+	mock, fleet := GivenMockedFleet()
+	err := fleet.Stop("unit.service")
+
+	Expect(err).To(Not(HaveOccurred()))
+	Expect(mock).To(containCall("SetUnitTargetState", "unit.service", unitStateLoaded))
+}
+
+func TestFleetDestroy_Success(t *testing.T) {
+	RegisterTestingT(t)
+
+	mock, fleet := GivenMockedFleet()
+	err := fleet.Destroy("unit.service")
+
+	Expect(err).To(Not(HaveOccurred()))
+	Expect(mock).To(containCall("DestroyUnit", "unit.service"))
 }


### PR DESCRIPTION
This PR tries to improve the test coverage of our `fleet/fleet.go` client by providing it with a mock that records the performed calls.

Future work can include configuring responses and ensuring calls were done in a specific order.
