### PR TITLE
handle slice expansion

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -65,8 +65,8 @@ func createSliceIDs(slices []string) ([]string, error) {
 		}
 		if len(found) == 0 {
 			// When there is no slice expression "@" given, we are dealing with a
-			// normal dirname, so we take the slice as it is.
-			found = []string{slice}
+			// normal dirname, so there is no slice ID required.
+			continue
 		}
 		sliceIDs = append(sliceIDs, atExp.ReplaceAllString(found[0], ""))
 	}

--- a/cli/common.go
+++ b/cli/common.go
@@ -10,8 +10,9 @@ import (
 
 var groupExp = regexp.MustCompile("@(.*)")
 
-func readUnitFiles(dirName string) (map[string]string, error) {
-	dirName = groupExp.ReplaceAllString(dirName, "")
+func readUnitFiles(slices []string) (map[string]string, error) {
+	slice := slices[0]
+	dirName := groupExp.ReplaceAllString(slice, "")
 
 	fileInfos, err := newFileSystem.ReadDir(dirName)
 	if err != nil {
@@ -37,24 +38,54 @@ func readUnitFiles(dirName string) (map[string]string, error) {
 
 var atExp = regexp.MustCompile("@")
 
-func createSliceIDs(dirName string) ([]string, error) {
-	list := groupExp.FindAllString(dirName, -1)
+func validateArgs(slices []string) error {
+	if len(slices) == 0 {
+		return maskAny(invalidArgumentsError)
+	}
 
+	baseSlice := slices[0]
+	baseSlice = groupExp.ReplaceAllString(baseSlice, "")
+
+	for _, slice := range slices {
+		slice = groupExp.ReplaceAllString(slice, "")
+		if slice != baseSlice {
+			return maskAny(invalidArgumentsError)
+		}
+	}
+
+	return nil
+}
+
+func createSliceIDs(slices []string) ([]string, error) {
 	sliceIDs := []string{}
-	for _, item := range list {
-		sliceIDs = append(sliceIDs, atExp.ReplaceAllString(item, ""))
+	for _, slice := range slices {
+		found := groupExp.FindAllString(slice, -1)
+		if len(found) > 1 {
+			return nil, maskAny(invalidArgumentsError)
+		}
+		if len(found) == 0 {
+			// When there is no slice expression "@" given, we are dealing with a
+			// normal dirname, so we take the slice as it is.
+			found = []string{slice}
+		}
+		sliceIDs = append(sliceIDs, atExp.ReplaceAllString(found[0], ""))
 	}
 
 	return sliceIDs, nil
 }
 
-func createRequest(dirName string) (controller.Request, error) {
+func createRequest(slices []string) (controller.Request, error) {
+	err := validateArgs(slices)
+	if err != nil {
+		return controller.Request{}, maskAny(err)
+	}
+
 	req := controller.Request{
 		SliceIDs: []string{},
 		Units:    []controller.Unit{},
 	}
 
-	unitFiles, err := readUnitFiles(dirName)
+	unitFiles, err := readUnitFiles(slices)
 	if err != nil {
 		return controller.Request{}, maskAny(err)
 	}
@@ -62,7 +93,7 @@ func createRequest(dirName string) (controller.Request, error) {
 		req.Units = append(req.Units, controller.Unit{Name: name, Content: content})
 	}
 
-	sliceIDs, err := createSliceIDs(dirName)
+	sliceIDs, err := createSliceIDs(slices)
 	if err != nil {
 		return controller.Request{}, maskAny(err)
 	}

--- a/cli/common_test.go
+++ b/cli/common_test.go
@@ -17,7 +17,7 @@ type testFileSystemSetup struct {
 func Test_Common_createRequest(t *testing.T) {
 	testCases := []struct {
 		Setup    []testFileSystemSetup
-		Input    string
+		Input    []string
 		Expected controller.Request
 	}{
 		// This test ensures that loading a single unit from a directory results in
@@ -30,7 +30,7 @@ func Test_Common_createRequest(t *testing.T) {
 					FilePerm:    os.FileMode(0644),
 				},
 			},
-			Input: "dirname",
+			Input: []string{"dirname"},
 			Expected: controller.Request{
 				SliceIDs: []string{},
 				Units: []controller.Unit{
@@ -52,9 +52,32 @@ func Test_Common_createRequest(t *testing.T) {
 					FilePerm:    os.FileMode(0644),
 				},
 			},
-			Input: "dirname@1",
+			Input: []string{"dirname@1"},
 			Expected: controller.Request{
 				SliceIDs: []string{"1"},
+				Units: []controller.Unit{
+					{
+						Name:    "dirname_unit@.service",
+						Content: "some unit content",
+					},
+				},
+			},
+		},
+
+		// This test ensures that loading a single unit from a directory with the
+		// slice expression "@1", "@foo" and "@5" results in the expected
+		// controller request.
+		{
+			Setup: []testFileSystemSetup{
+				{
+					FileName:    "dirname/dirname_unit@.service",
+					FileContent: []byte("some unit content"),
+					FilePerm:    os.FileMode(0644),
+				},
+			},
+			Input: []string{"dirname@1"},
+			Expected: controller.Request{
+				SliceIDs: []string{"1", "foo", "5"},
 				Units: []controller.Unit{
 					{
 						Name:    "dirname_unit@.service",

--- a/cli/common_test.go
+++ b/cli/common_test.go
@@ -25,7 +25,7 @@ func Test_Common_createRequest(t *testing.T) {
 		{
 			Setup: []testFileSystemSetup{
 				{
-					FileName:    "dirname/dirname_unit@.service",
+					FileName:    "dirname/dirname_unit.service",
 					FileContent: []byte("some unit content"),
 					FilePerm:    os.FileMode(0644),
 				},
@@ -35,7 +35,7 @@ func Test_Common_createRequest(t *testing.T) {
 				SliceIDs: []string{},
 				Units: []controller.Unit{
 					{
-						Name:    "dirname_unit@.service",
+						Name:    "dirname_unit.service",
 						Content: "some unit content",
 					},
 				},
@@ -75,7 +75,7 @@ func Test_Common_createRequest(t *testing.T) {
 					FilePerm:    os.FileMode(0644),
 				},
 			},
-			Input: []string{"dirname@1"},
+			Input: []string{"dirname@1", "dirname@foo", "dirname@5"},
 			Expected: controller.Request{
 				SliceIDs: []string{"1", "foo", "5"},
 				Units: []controller.Unit{
@@ -88,7 +88,7 @@ func Test_Common_createRequest(t *testing.T) {
 		},
 	}
 
-	for _, testCase := range testCases {
+	for i, testCase := range testCases {
 		newFileSystem = filesystemfake.NewFileSystem()
 
 		for _, setup := range testCase.Setup {
@@ -101,6 +101,10 @@ func Test_Common_createRequest(t *testing.T) {
 		output, err := createRequest(testCase.Input)
 		if err != nil {
 			t.Fatalf("createRequest returned error: %#v", err)
+		}
+
+		if len(output.SliceIDs) != len(testCase.Expected.SliceIDs) {
+			t.Fatalf("(test case %d) sliceIDs of generated output differs from expected sliceIDs", i+1)
 		}
 
 		for i, outputUnit := range output.Units {

--- a/cli/error.go
+++ b/cli/error.go
@@ -7,3 +7,5 @@ import (
 var (
 	maskAny = errgo.MaskFunc(errgo.Any)
 )
+
+var invalidArgumentsError = errgo.Newf("invalid arguments")

--- a/cli/status.go
+++ b/cli/status.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	statusCmd = &cobra.Command{
-		Use:   "status [group]",
+		Use:   "status [group-slice] ...",
 		Short: "status of a group",
 		Long:  "status of a group",
 		Run:   statusRun,
@@ -17,12 +17,7 @@ var (
 )
 
 func statusRun(cmd *cobra.Command, args []string) {
-	if len(args) != 1 {
-		cmd.Help()
-		os.Exit(1)
-	}
-
-	req, err := createRequest(args[0])
+	req, err := createRequest(args)
 	if err != nil {
 		fmt.Printf("%#v\n", maskAny(err))
 		os.Exit(1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# docs
+Here we document important concepts and functionality formica supports.
+
+### table of contents
+- [slice expansion](slice_expansion.md)

--- a/docs/slice_expansion.md
+++ b/docs/slice_expansion.md
@@ -20,17 +20,17 @@ Formica takes these arguments and looks up the directory `myapp`. Then the
 slice IDs `1`, `2` and `3` are used to create the unit file names accordingly.
 So lets imagine there are this two unit files within `myapp`.
 ```
-some_unit_name@.service
-some_other_unit_name@.service
+myapp_some_unit_name@.service
+myapp_some_other_unit_name@.service
 ```
 
 Given the 3 slice IDs and the unit file names the resulting unit file names
 that are going to be created for our `submit` command are the following.
 ```
-some_unit_name@1.service
-some_other_unit_name@1.service
-some_unit_name@2.service
-some_other_unit_name@2.service
-some_unit_name@3.service
-some_other_unit_name@3.service
+myapp_some_unit_name@1.service
+myapp_some_other_unit_name@1.service
+myapp_some_unit_name@2.service
+myapp_some_other_unit_name@2.service
+myapp_some_unit_name@3.service
+myapp_some_other_unit_name@3.service
 ```

--- a/docs/slice_expansion.md
+++ b/docs/slice_expansion.md
@@ -1,0 +1,36 @@
+# slice expansion
+Slice expansion is a feature to provide multiple slices using one command line
+argument in your shell. In fact the argument expansion is a feature of common
+shells. So you can do things like this.
+
+```
+formica submit myapp@{1..3}
+```
+
+This assumes there is a directory `myapp`. The expression `@{1..3}` tells
+formica to create 3 slices. Your shell expands the argument `myapp@{1..3}` to
+the following arguments that formica receives.
+```
+myapp@1
+myapp@2
+myapp@3
+```
+
+Formica takes these arguments and looks up the directory `myapp`. Then the
+slice IDs `1`, `2` and `3` are used to create the unit file names accordingly.
+So lets imagine there are this two unit files within `myapp`.
+```
+some_unit_name@.service
+some_other_unit_name@.service
+```
+
+Given the 3 slice IDs and the unit file names the resulting unit file names
+that are going to be created for our `submit` command are the following.
+```
+some_unit_name@1.service
+some_other_unit_name@1.service
+some_unit_name@2.service
+some_other_unit_name@2.service
+some_unit_name@3.service
+some_other_unit_name@3.service
+```


### PR DESCRIPTION
I checked `fleetctl` and there is no range expansion for the slices. So `fleetctl start unit@{1..3}` is supported via the executing shell. The result is this `{"units/simple@1.service", "units/simple@2.service", "units/simple@3.service"}`. We now need to handle the arguments properly.

RFR @JosephSalisbury @zeisss 
