### PR TITLE
basic status output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean:
 	@builder get dep -b 08cceb5d0b5331634b9826762a8fd53b29b86ad8 https://github.com/juju/errgo.git $(GOPATH)/src/github.com/juju/errgo
 	@builder get dep -b 65a708cee0a4424f4e353d031ce440643e312f92 https://github.com/spf13/cobra.git $(GOPATH)/src/github.com/spf13/cobra
 	@builder get dep -b 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7 https://github.com/spf13/pflag.git $(GOPATH)/src/github.com/spf13/pflag
+	@builder get dep -b 983d3a5fab1bf04d1b412465d2d9f8430e2e917e https://github.com/ryanuber/columnize.git $(GOPATH)/src/github.com/ryanuber/columnize
 
 	@builder get dep https://github.com/onsi/gomega.git $(GOPATH)/src/github.com/onsi/gomega
 deps:

--- a/cli/common.go
+++ b/cli/common.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/ryanuber/columnize"
+
 	"github.com/giantswarm/formica/controller"
 	"github.com/giantswarm/formica/fleet"
 )
@@ -129,7 +131,32 @@ func createRequest(slices []string) (controller.Request, error) {
 	return req, nil
 }
 
-func printStatus(groupStatus []fleet.UnitStatus) error {
-	fmt.Printf("%#v\n", groupStatus)
+var (
+	statusHeader = "Group | Units | FDState | FCState | SAState | IP | Machine"
+	statusBody   = "%s | %s | %s | %s | %s | %s | %s"
+)
+
+func printStatus(group string, groupStatus []fleet.UnitStatus) error {
+	data := []string{
+		statusHeader,
+		"",
+	}
+
+	for _, us := range groupStatus {
+		for _, ms := range us.Machine {
+			row := fmt.Sprintf(
+				statusBody,
+				group,
+				us.Name,
+				us.Desired,
+				us.Current,
+				ms.SystemdActive,
+				ms.IP,
+				ms.ID,
+			)
+			data = append(data, row)
+		}
+	}
+	fmt.Println(columnize.SimpleFormat(data))
 	return nil
 }

--- a/cli/status.go
+++ b/cli/status.go
@@ -23,13 +23,14 @@ func statusRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	status, err := newController.GetStatus(req)
+	statusList, err := newController.GetStatus(req)
 	if err != nil {
 		fmt.Printf("%#v\n", maskAny(err))
 		os.Exit(1)
 	}
 
-	err = printStatus(status)
+	group := dirnameFromSlices(args)
+	err = printStatus(group, statusList)
 	if err != nil {
 		fmt.Printf("%#v\n", maskAny(err))
 		os.Exit(1)

--- a/cli/status.go
+++ b/cli/status.go
@@ -3,8 +3,11 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/formica/controller"
 )
 
 var (
@@ -23,13 +26,19 @@ func statusRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	group := dirnameFromSlices(args)
 	statusList, err := newController.GetStatus(req)
-	if err != nil {
+	if controller.IsUnitNotFound(err) {
+		fmt.Printf("No unit found for group slice(s) '%s'.\n", args)
+		os.Exit(1)
+	} else if controller.IsUnitSliceNotFound(err) {
+		fmt.Printf("%s%s.\n", strings.ToUpper(err.Error()[0:1]), err.Error()[1:])
+		os.Exit(1)
+	} else if err != nil {
 		fmt.Printf("%#v\n", maskAny(err))
 		os.Exit(1)
 	}
 
-	group := dirnameFromSlices(args)
 	err = printStatus(group, statusList)
 	if err != nil {
 		fmt.Printf("%#v\n", maskAny(err))

--- a/controller/error.go
+++ b/controller/error.go
@@ -1,9 +1,43 @@
 package controller
 
 import (
+	"fmt"
+
 	"github.com/juju/errgo"
 )
 
 var (
 	maskAny = errgo.MaskFunc(errgo.Any)
 )
+
+func maskAnyf(err error, f string, v ...interface{}) error {
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+
+	if e, _ := newErr.(*errgo.Err); e != nil {
+		e.SetLocation(1)
+		return e
+	}
+
+	return err
+}
+
+var unitNotFoundError = errgo.New("unit not found")
+
+// IsUnitNotFound checks whether the given error indicates the problem of an
+// unit being found or not. In case you want to lookup the state of a group and
+// no unit of it can be found on any machine, an error that you can identify
+// using this method is returned.
+func IsUnitNotFound(err error) bool {
+	return errgo.Cause(err) == unitNotFoundError
+}
+
+var unitSliceNotFoundError = errgo.New("unit slice not found")
+
+// IsUnitSliceNotFound checks whether the given error indicates the problem of
+// an unit slice being found or not. In case you want to lookup the state of a
+// group and some unit of this group cannot be found on any machine, an error
+// that you can identify using this method is returned.
+func IsUnitSliceNotFound(err error) bool {
+	return errgo.Cause(err) == unitSliceNotFoundError
+}

--- a/fleet/fleet_client_mock_test.go
+++ b/fleet/fleet_client_mock_test.go
@@ -51,7 +51,8 @@ func (matcher *containsCallMatcher) NegatedFailureMessage(actual interface{}) (m
 }
 
 type fleetClientMock struct {
-	calls []mockCall
+	calls    []mockCall
+	machines []machine.MachineState
 }
 
 func (fleet *fleetClientMock) Calls() []mockCall {
@@ -60,7 +61,7 @@ func (fleet *fleetClientMock) Calls() []mockCall {
 
 func (fleet *fleetClientMock) Machines() ([]machine.MachineState, error) {
 	fleet.calls = append(fleet.calls, mockCall{"Machines", []interface{}{}})
-	return nil, nil
+	return fleet.machines, nil
 }
 
 func (fleet *fleetClientMock) Unit(unit string) (*schema.Unit, error) {

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -1,10 +1,13 @@
 package fleet
 
 import (
+	"net"
+	"reflect"
 	"testing"
 
 	. "github.com/onsi/gomega"
 
+	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/schema"
 )
 
@@ -20,6 +23,16 @@ func TestDefaultConfig(t *testing.T) {
 
 func GivenMockedFleet() (*fleetClientMock, *fleet) {
 	mock := &fleetClientMock{}
+	return mock, &fleet{
+		Client: mock,
+		Config: DefaultConfig(),
+	}
+}
+
+func GivenMockedFleetWithMachines(machines []machine.MachineState) (*fleetClientMock, *fleet) {
+	mock := &fleetClientMock{
+		machines: machines,
+	}
 	return mock, &fleet{
 		Client: mock,
 		Config: DefaultConfig(),
@@ -75,4 +88,93 @@ func TestFleetDestroy_Success(t *testing.T) {
 
 	Expect(err).To(Not(HaveOccurred()))
 	Expect(mock).To(containCall("DestroyUnit", "unit.service"))
+}
+
+func Test_Fleet_createOurStatusList(t *testing.T) {
+	testCases := []struct {
+		Error                error
+		FoundFleetUnits      []*schema.Unit
+		FoundFleetUnitStates []*schema.UnitState
+		FleetMachines        []machine.MachineState
+		UnitStatusList       []UnitStatus
+	}{
+		// ..
+		{
+			Error: nil,
+			FoundFleetUnits: []*schema.Unit{
+				{
+					CurrentState: "current-state-1",
+					DesiredState: "desired-state-1",
+					MachineID:    "machine-ID-1",
+					Name:         "name-1",
+				},
+				{
+					CurrentState: "current-state-2",
+					DesiredState: "desired-state-2",
+					MachineID:    "machine-ID-2",
+					Name:         "name-2",
+				},
+			},
+			FoundFleetUnitStates: []*schema.UnitState{
+				{
+					MachineID:          "machine-ID-1",
+					Name:               "name-1",
+					SystemdActiveState: "systemd-active-state-1",
+				},
+				{
+					MachineID:          "machine-ID-2",
+					Name:               "name-2",
+					SystemdActiveState: "systemd-active-state-2",
+				},
+			},
+			FleetMachines: []machine.MachineState{
+				{
+					ID:       "machine-ID-1",
+					PublicIP: "10.0.0.1",
+				},
+				{
+					ID:       "machine-ID-2",
+					PublicIP: "10.0.0.2",
+				},
+			},
+			UnitStatusList: []UnitStatus{
+				{
+					Current: "current-state-1",
+					Desired: "desired-state-1",
+					Machine: []MachineStatus{
+						{
+							ID:            "machine-ID-1",
+							IP:            net.ParseIP("10.0.0.1"),
+							SystemdActive: "systemd-active-state-1",
+						},
+					},
+					Name: "name-1",
+				},
+				{
+					Current: "current-state-2",
+					Desired: "desired-state-2",
+					Machine: []MachineStatus{
+						{
+							ID:            "machine-ID-2",
+							IP:            net.ParseIP("10.0.0.2"),
+							SystemdActive: "systemd-active-state-2",
+						},
+					},
+					Name: "name-2",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		_, fleet := GivenMockedFleetWithMachines(testCase.FleetMachines)
+		ourStatusList, err := fleet.createOurStatusList(testCase.FoundFleetUnits, testCase.FoundFleetUnitStates)
+		if err != nil {
+			t.Fatalf("Fleet.createOurStatusList returned error: %#v", err)
+		}
+
+		if !reflect.DeepEqual(ourStatusList, testCase.UnitStatusList) {
+			t.Fatalf("generated status list '%#v' is not equal to expected status list '%#v'", ourStatusList, testCase.UnitStatusList)
+		}
+	}
 }

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -98,7 +98,8 @@ func Test_Fleet_createOurStatusList(t *testing.T) {
 		FleetMachines        []machine.MachineState
 		UnitStatusList       []UnitStatus
 	}{
-		// ..
+		// This test ensures that creating our own status structures works as
+		// expected.
 		{
 			Error: nil,
 			FoundFleetUnits: []*schema.Unit{


### PR DESCRIPTION
This is to get the V1 workflow right. That is submit units and query their status.

``` bash
# no units submit, no status
core@core-01 ~ $ ./formicactl status units@{1..3}
No unit found for group slice(s) '[units@1 units@2 units@3]'.

# submit units
core@core-01 ~ $ ./formicactl submit units@{1..3}

# check status
core@core-01 ~ $ ./formicactl status units@{1..3}
Group  Units                   FDState  FCState  SAState   IP              Machine

units  units_simple@1.service  loaded   loaded   inactive  192.168.33.102  b25ded3e1a944b9bb5a91124f55f1662
units  units_simple@2.service  loaded   loaded   inactive  192.168.33.103  027494415d6848078626e57fff3cf801
units  units_simple@3.service  loaded   loaded   inactive  192.168.33.101  49ecbf33492c4beaaa5cd9fe72ee881a

# invalid slice
core@core-01 ~ $ ./formicactl status units@{1..4}
Unit slice not found: slice ID '4'.
```
