### PR TITLE
Fleet status tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ clean:
 	@builder get dep -b 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7 https://github.com/spf13/pflag.git $(GOPATH)/src/github.com/spf13/pflag
 
 	@builder get dep https://github.com/onsi/gomega.git $(GOPATH)/src/github.com/onsi/gomega
+	@builder get dep https://github.com/stretchr/testify.git $(GOPATH)/src/github.com/stretchr/testify
+	@builder get dep https://github.com/davecgh/go-spew.git $(GOPATH)/src/github.com/davecgh/go-spew
+	@builder get dep https://github.com/pmezard/go-difflib.git $(GOPATH)/src/github.com/pmezard/go-difflib
+	@builder get dep https://github.com/stretchr/objx.git $(GOPATH)/src/github.com/stretchr/objx
 deps:
 	@${MAKE} -B -s .gobuild
 

--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -217,7 +217,7 @@ func (f fleet) Destroy(name string) error {
 func (f fleet) GetStatus(name string) (UnitStatus, error) {
 	matcher := func(s string) bool {
 		return name == s
-	}	
+	}
 	unitStatus, err := f.GetStatusWithMatcher(matcher)
 	if err != nil {
 		return UnitStatus{}, maskAny(err)

--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -215,12 +215,10 @@ func (f fleet) Destroy(name string) error {
 }
 
 func (f fleet) GetStatus(name string) (UnitStatus, error) {
-	exp, err := regexp.Compile(fmt.Sprintf("^%s$", name))
-	if err != nil {
-		return UnitStatus{}, maskAny(err)
-	}
-
-	unitStatus, err := f.GetStatusWithExpression(exp)
+	matcher := func(s string) bool {
+		return name == s
+	}	
+	unitStatus, err := f.GetStatusWithMatcher(matcher)
 	if err != nil {
 		return UnitStatus{}, maskAny(err)
 	}
@@ -233,6 +231,13 @@ func (f fleet) GetStatus(name string) (UnitStatus, error) {
 }
 
 func (f fleet) GetStatusWithExpression(exp *regexp.Regexp) ([]UnitStatus, error) {
+	status, err := f.GetStatusWithMatcher(exp.MatchString)
+	return status, maskAny(err)
+}
+
+// GetStatusWithMatcher returns a UnitStatus for each unit where the given matcher
+// returns true.
+func (f fleet) GetStatusWithMatcher(matcher func(s string) bool) ([]UnitStatus, error) {
 	// Lookup fleet cluster state.
 	fleetUnits, err := f.Client.Units()
 	if err != nil {
@@ -240,7 +245,7 @@ func (f fleet) GetStatusWithExpression(exp *regexp.Regexp) ([]UnitStatus, error)
 	}
 	foundFleetUnits := []*schema.Unit{}
 	for _, fu := range fleetUnits {
-		if exp.MatchString(fu.Name) {
+		if matcher(fu.Name) {
 			foundFleetUnits = append(foundFleetUnits, fu)
 		}
 	}
@@ -256,7 +261,7 @@ func (f fleet) GetStatusWithExpression(exp *regexp.Regexp) ([]UnitStatus, error)
 	}
 	var foundFleetUnitStates []*schema.UnitState
 	for _, fus := range fleetUnitStates {
-		if exp.MatchString(fus.Name) {
+		if matcher(fus.Name) {
 			foundFleetUnitStates = append(foundFleetUnitStates, fus)
 		}
 	}

--- a/fleet/fleet_client_mock_test.go
+++ b/fleet/fleet_client_mock_test.go
@@ -20,7 +20,7 @@ type callRecorder interface {
 //
 func containCall(name string, args ...interface{}) types.GomegaMatcher {
 	return &containsCallMatcher{mock.Call{
-		Method: name,
+		Method:    name,
 		Arguments: args,
 	}}
 }

--- a/fleet/fleet_client_mock_test.go
+++ b/fleet/fleet_client_mock_test.go
@@ -11,7 +11,7 @@ import (
 
 // callRecorder returns the recorded calls
 type callRecorder interface {
-	Mock() mock.Mock
+	TestifyMock() mock.Mock
 }
 
 // containCall returns a new GomegaMatcher to test if a given call was made.
@@ -31,7 +31,7 @@ type containsCallMatcher struct {
 
 func (matcher *containsCallMatcher) Match(actual interface{}) (success bool, err error) {
 	client := actual.(callRecorder)
-	mock := client.Mock()
+	mock := client.TestifyMock()
 
 	for _, call := range mock.Calls {
 		if call.Method != matcher.Method {
@@ -55,40 +55,40 @@ func (matcher *containsCallMatcher) NegatedFailureMessage(actual interface{}) (m
 }
 
 type fleetClientMock struct {
-	mock mock.Mock
+	mock.Mock
 }
 
-func (fleet *fleetClientMock) Mock() mock.Mock {
-	return fleet.mock
+func (fleet *fleetClientMock) TestifyMock() mock.Mock {
+	return fleet.Mock
 }
 
 func (fleet *fleetClientMock) Machines() ([]machine.MachineState, error) {
-	args := fleet.mock.Called()
+	args := fleet.Called()
 	return args.Get(0).([]machine.MachineState), args.Error(1)
 }
 
 func (fleet *fleetClientMock) Unit(unit string) (*schema.Unit, error) {
-	args := fleet.mock.Called(unit)
+	args := fleet.Called(unit)
 	return args.Get(0).(*schema.Unit), args.Error(1)
 }
 func (fleet *fleetClientMock) Units() ([]*schema.Unit, error) {
-	args := fleet.mock.Called()
+	args := fleet.Called()
 	return args.Get(0).([]*schema.Unit), args.Error(1)
 }
 func (fleet *fleetClientMock) UnitStates() ([]*schema.UnitState, error) {
-	args := fleet.mock.Called()
+	args := fleet.Called()
 	return args.Get(0).([]*schema.UnitState), args.Error(1)
 }
 
 func (fleet *fleetClientMock) SetUnitTargetState(name, target string) error {
-	args := fleet.mock.Called(name, target)
+	args := fleet.Called(name, target)
 	return args.Error(0)
 }
 func (fleet *fleetClientMock) CreateUnit(unit *schema.Unit) error {
-	args := fleet.mock.Called(unit)
+	args := fleet.Called(unit)
 	return args.Error(0)
 }
 func (fleet *fleetClientMock) DestroyUnit(unit string) error {
-	args := fleet.mock.Called(unit)
+	args := fleet.Called(unit)
 	return args.Error(0)
 }

--- a/fleet/fleet_client_mock_test.go
+++ b/fleet/fleet_client_mock_test.go
@@ -2,21 +2,16 @@ package fleet
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/schema"
 	"github.com/onsi/gomega/types"
+	"github.com/stretchr/testify/mock"
 )
 
 // callRecorder returns the recorded calls
 type callRecorder interface {
-	Calls() []mockCall
-}
-
-type mockCall struct {
-	Name string
-	Args []interface{}
+	Mock() mock.Mock
 }
 
 // containCall returns a new GomegaMatcher to test if a given call was made.
@@ -24,67 +19,76 @@ type mockCall struct {
 //     Expect(callRecorderObj).To(containCall("functionName", arg1, arg2))
 //
 func containCall(name string, args ...interface{}) types.GomegaMatcher {
-	return &containsCallMatcher{mockCall{
-		name, args,
+	return &containsCallMatcher{mock.Call{
+		Method: name,
+		Arguments: args,
 	}}
 }
 
 type containsCallMatcher struct {
-	expectedCall mockCall
+	mock.Call
 }
 
 func (matcher *containsCallMatcher) Match(actual interface{}) (success bool, err error) {
 	client := actual.(callRecorder)
+	mock := client.Mock()
 
-	for _, call := range client.Calls() {
-		if reflect.DeepEqual(matcher.expectedCall, call) {
-			return true, nil
+	for _, call := range mock.Calls {
+		if call.Method != matcher.Method {
+			continue
 		}
+
+		_, differences := call.Arguments.Diff(matcher.Arguments)
+		if differences == 0 {
+			continue
+		}
+
+		return true, nil
 	}
 	return false, nil
 }
 func (matcher *containsCallMatcher) FailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nto contain call\n\t%#v", actual, matcher.expectedCall)
+	return fmt.Sprintf("Expected\n\t%#v\nto contain call\n\t%#v", actual, matcher.Call)
 }
 func (matcher *containsCallMatcher) NegatedFailureMessage(actual interface{}) (message string) {
-	return fmt.Sprintf("Expected\n\t%#v\nnot to contain call\n\t%#v", actual, matcher.expectedCall)
+	return fmt.Sprintf("Expected\n\t%#v\nnot to contain call\n\t%#v", actual, matcher.Call)
 }
 
 type fleetClientMock struct {
-	calls []mockCall
+	mock mock.Mock
 }
 
-func (fleet *fleetClientMock) Calls() []mockCall {
-	return fleet.calls
+func (fleet *fleetClientMock) Mock() mock.Mock {
+	return fleet.mock
 }
 
 func (fleet *fleetClientMock) Machines() ([]machine.MachineState, error) {
-	fleet.calls = append(fleet.calls, mockCall{"Machines", []interface{}{}})
-	return nil, nil
+	args := fleet.mock.Called()
+	return args.Get(0).([]machine.MachineState), args.Error(1)
 }
 
 func (fleet *fleetClientMock) Unit(unit string) (*schema.Unit, error) {
-	fleet.calls = append(fleet.calls, mockCall{"Unit", []interface{}{unit}})
-	return nil, nil
+	args := fleet.mock.Called(unit)
+	return args.Get(0).(*schema.Unit), args.Error(1)
 }
 func (fleet *fleetClientMock) Units() ([]*schema.Unit, error) {
-	fleet.calls = append(fleet.calls, mockCall{"Units", []interface{}{}})
-	return nil, nil
+	args := fleet.mock.Called()
+	return args.Get(0).([]*schema.Unit), args.Error(1)
 }
 func (fleet *fleetClientMock) UnitStates() ([]*schema.UnitState, error) {
-	fleet.calls = append(fleet.calls, mockCall{"UnitStates", []interface{}{}})
-	return nil, nil
+	args := fleet.mock.Called()
+	return args.Get(0).([]*schema.UnitState), args.Error(1)
 }
 
 func (fleet *fleetClientMock) SetUnitTargetState(name, target string) error {
-	fleet.calls = append(fleet.calls, mockCall{"SetUnitTargetState", []interface{}{name, target}})
-	return nil
+	args := fleet.mock.Called(name, target)
+	return args.Error(0)
 }
 func (fleet *fleetClientMock) CreateUnit(unit *schema.Unit) error {
-	fleet.calls = append(fleet.calls, mockCall{"CreateUnit", []interface{}{unit}})
-	return nil
+	args := fleet.mock.Called(unit)
+	return args.Error(0)
 }
 func (fleet *fleetClientMock) DestroyUnit(unit string) error {
-	fleet.calls = append(fleet.calls, mockCall{"DestroyUnit", []interface{}{unit}})
-	return nil
+	args := fleet.mock.Called(unit)
+	return args.Error(0)
 }

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -31,7 +31,7 @@ func GivenMockedFleet() (*fleetClientMock, *fleet) {
 
 func GivenMockedFleetWithMachines(machines []machine.MachineState) (*fleetClientMock, *fleet) {
 	fleetClientMock, fleet := GivenMockedFleet()
-	fleetClientMock.mock.On("Machines").Return(machines, nil)
+	fleetClientMock.On("Machines").Return(machines, nil)
 	return fleetClientMock, fleet
 }
 
@@ -39,7 +39,7 @@ func TestFleetSubmit_Success(t *testing.T) {
 	RegisterTestingT(t)
 
 	fleetClientMock, fleet := GivenMockedFleet()
-	fleetClientMock.mock.On("CreateUnit", mock.AnythingOfType("*schema.Unit")).Once().Return(nil, nil)
+	fleetClientMock.On("CreateUnit", mock.AnythingOfType("*schema.Unit")).Once().Return(nil, nil)
 	err := fleet.Submit("unit.service", "[Unit]\n"+
 		"Description=This is a test unit\n"+
 		"[Service]\n"+
@@ -47,7 +47,7 @@ func TestFleetSubmit_Success(t *testing.T) {
 
 	Expect(err).To(Not(HaveOccurred()))
 
-	fleetClientMock.mock.AssertCalled(
+	fleetClientMock.AssertCalled(
 		t,
 		"CreateUnit",
 		mock.MatchedBy(func(unit *schema.Unit) bool {
@@ -61,34 +61,34 @@ func TestFleetStart_Success(t *testing.T) {
 	RegisterTestingT(t)
 
 	mock, fleet := GivenMockedFleet()
-	mock.mock.On("SetUnitTargetState", "unit.service", unitStateLaunched).Once().Return(nil)
+	mock.On("SetUnitTargetState", "unit.service", unitStateLaunched).Once().Return(nil)
 
 	err := fleet.Start("unit.service")
 
 	Expect(err).To(Not(HaveOccurred()))
-	mock.mock.AssertExpectations(t)
+	mock.AssertExpectations(t)
 }
 
 func TestFleetStop_Success(t *testing.T) {
 	RegisterTestingT(t)
 
 	mock, fleet := GivenMockedFleet()
-	mock.mock.On("SetUnitTargetState", "unit.service", unitStateLoaded).Once().Return(nil)
+	mock.On("SetUnitTargetState", "unit.service", unitStateLoaded).Once().Return(nil)
 	err := fleet.Stop("unit.service")
 
 	Expect(err).To(Not(HaveOccurred()))
-	mock.mock.AssertExpectations(t)
+	mock.AssertExpectations(t)
 }
 
 func TestFleetDestroy_Success(t *testing.T) {
 	RegisterTestingT(t)
 
 	mock, fleet := GivenMockedFleet()
-	mock.mock.On("DestroyUnit", "unit.service").Once().Return(nil)
+	mock.On("DestroyUnit", "unit.service").Once().Return(nil)
 	err := fleet.Destroy("unit.service")
 
 	Expect(err).To(Not(HaveOccurred()))
-	mock.mock.AssertExpectations(t)
+	mock.AssertExpectations(t)
 }
 
 func TestFleetGetStatusWithMatcher__Success(t *testing.T) {
@@ -98,11 +98,11 @@ func TestFleetGetStatusWithMatcher__Success(t *testing.T) {
 
 	// Mocking
 	fleetClientMock, fleet := GivenMockedFleet()
-	fleetClientMock.mock.On("Units").Return([]*schema.Unit{
+	fleetClientMock.On("Units").Return([]*schema.Unit{
 		{Name: "unit.service", CurrentState: unitStateLaunched, DesiredState: unitStateLaunched},
 		{Name: "other.service", CurrentState: unitStateInactive, DesiredState: unitStateInactive},
 	}, nil).Once()
-	fleetClientMock.mock.On("UnitStates").Return([]*schema.UnitState{
+	fleetClientMock.On("UnitStates").Return([]*schema.UnitState{
 		{
 			Name:               "unit.service",
 			MachineID:          machineID,
@@ -111,7 +111,7 @@ func TestFleetGetStatusWithMatcher__Success(t *testing.T) {
 		// other.service is not scheduled
 	}, nil).Once()
 
-	fleetClientMock.mock.On("Machines").Return([]machine.MachineState{
+	fleetClientMock.On("Machines").Return([]machine.MachineState{
 		{ID: machineID, PublicIP: "10.0.0.100"},
 		{ID: "otherID", PublicIP: "10.0.0.254"},
 	}, nil).Once()

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -1,14 +1,14 @@
 package fleet
 
 import (
-	"testing"
 	"net"
+	"testing"
 
 	. "github.com/onsi/gomega"
 
+	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/schema"
 	"github.com/stretchr/testify/mock"
-	"github.com/coreos/fleet/machine"
 )
 
 // TestDefaultConfig verifies that the default config contains a basic valid fleet config
@@ -98,8 +98,8 @@ func TestFleetGetStatusWithMatcher__Success(t *testing.T) {
 	}, nil).Once()
 	fleetClientMock.mock.On("UnitStates").Return([]*schema.UnitState{
 		{
-			Name: "unit.service",
-			MachineID: machineID,
+			Name:               "unit.service",
+			MachineID:          machineID,
 			SystemdActiveState: "running",
 		},
 		// other.service is not scheduled
@@ -114,19 +114,19 @@ func TestFleetGetStatusWithMatcher__Success(t *testing.T) {
 	matcher := func(s string) bool {
 		return s == "unit.service"
 	}
+	status, err := fleet.GetStatusWithMatcher(matcher)
 
 	// Assertion
-	status, err := fleet.GetStatusWithMatcher(matcher)
 	Expect(err).To(Not(HaveOccurred()))
 	Expect(len(status)).To(Equal(1))
 	Expect(status[0]).To(Equal(UnitStatus{
-		Name: "unit.service",
+		Name:    "unit.service",
 		Current: unitStateLaunched,
 		Desired: unitStateLaunched,
 		Machine: []MachineStatus{
 			{
-				ID: machineID,
-				IP: net.ParseIP("10.0.0.100"),
+				ID:            machineID,
+				IP:            net.ParseIP("10.0.0.100"),
 				SystemdActive: "running",
 			},
 		},


### PR DESCRIPTION
- Replaces the custom mock with a library which also provides to define number of calls, not calls etc.
- Add test for simple successfull `fleet.GetStatus` call
- Refactors `fleet` to have a `GetStatusWithMatcher` func so we don't need a regexp everywhere

Will have merge conflicts after https://github.com/giantswarm/formica/pull/25

<!---
@huboard:{"custom_state":"archived"}
-->
