### PR TITLE
fleet: Simplify code by making 'createOutStatusList'  deterministic

### DIFF
--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -29,16 +29,6 @@ func GivenMockedFleet() (*fleetClientMock, *fleet) {
 	}
 }
 
-func GivenMockedFleetWithMachines(machines []machine.MachineState) (*fleetClientMock, *fleet) {
-	mock := &fleetClientMock{
-		machines: machines,
-	}
-	return mock, &fleet{
-		Client: mock,
-		Config: DefaultConfig(),
-	}
-}
-
 func TestFleetSubmit_Success(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -168,8 +158,8 @@ func Test_Fleet_createOurStatusList(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		_, fleet := GivenMockedFleetWithMachines(testCase.FleetMachines)
-		ourStatusList, err := fleet.createOurStatusList(testCase.FoundFleetUnits, testCase.FoundFleetUnitStates)
+		_, fleet := GivenMockedFleet()
+		ourStatusList, err := fleet.createOurStatusList(testCase.FoundFleetUnits, testCase.FoundFleetUnitStates, testCase.FleetMachines)
 		if err != nil {
 			t.Fatalf("Fleet.createOurStatusList returned error: %#v", err)
 		}


### PR DESCRIPTION
This PR changes the fleet wrapper to have a more deterministic 'createOurStatusList'  function by having all important facts as inputs. The only that can now occur here is the `ipNotFoundErr`.
