### PR TITLE
formicactl: Added start command. Actions now work on the specified sl…

### DIFF
--- a/cli/formicactl.go
+++ b/cli/formicactl.go
@@ -57,6 +57,7 @@ func init() {
 
 	MainCmd.AddCommand(submitCmd)
 	MainCmd.AddCommand(statusCmd)
+	MainCmd.AddCommand(startCmd)
 }
 
 func mainRun(cmd *cobra.Command, args []string) {

--- a/cli/start.go
+++ b/cli/start.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	startCmd = &cobra.Command{
+		Use:   "start [group [group..]]",
+		Short: "Starts the specified group or slices",
+		Long:  "Starts a group or the specified slices",
+		Run:   startRun,
+	}
+)
+
+func startRun(cmd *cobra.Command, args []string) {
+	req, err := createRequest(args)
+	if err != nil {
+		fmt.Printf("%#v\n", maskAny(err))
+		os.Exit(1)
+	}
+
+	err = newController.Start(req)
+	if err != nil {
+		fmt.Printf("%#v\n", maskAny(err))
+		os.Exit(1)
+	}
+
+	if req.SliceIDs == nil {
+		fmt.Printf("Started group '%s'\n", req.Group)
+	} else if len(req.SliceIDs) == 0 {
+		fmt.Printf("Started all slices of group '%s'\n", req.Group)
+	} else {
+		fmt.Printf("Started %d slices for group '%s': %v", len(req.SliceIDs), req.Group, req.SliceIDs)
+	}
+}

--- a/controller/fleet_mock_test.go
+++ b/controller/fleet_mock_test.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"regexp"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/giantswarm/formica/fleet"
+)
+
+type fleetMock struct {
+	mock.Mock
+}
+
+func (fm *fleetMock) Submit(name, content string) error {
+	args := fm.Called(name, content)
+	return args.Error(0)
+}
+func (fm *fleetMock) Start(name string) error {
+	args := fm.Called(name)
+	return args.Error(0)
+}
+func (fm *fleetMock) Stop(name string) error {
+	args := fm.Called(name)
+	return args.Error(0)
+}
+func (fm *fleetMock) Destroy(name string) error {
+	args := fm.Called(name)
+	return args.Error(0)
+}
+func (fm *fleetMock) GetStatus(name string) (fleet.UnitStatus, error) {
+	args := fm.Called(name)
+	return args.Get(0).(fleet.UnitStatus), args.Error(1)
+}
+func (fm *fleetMock) GetStatusWithExpression(exp *regexp.Regexp) ([]fleet.UnitStatus, error) {
+	args := fm.Called(exp)
+	return args.Get(0).([]fleet.UnitStatus), args.Error(1)
+}
+func (fm *fleetMock) GetStatusWithMatcher(f func(string) bool) ([]fleet.UnitStatus, error) {
+	args := fm.Called(f)
+	return args.Get(0).([]fleet.UnitStatus), args.Error(1)
+}

--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -103,6 +103,10 @@ type Fleet interface {
 	// GetStatusWithExpression fetches the current status of units based on a
 	// regular expression instead of a plain string.
 	GetStatusWithExpression(exp *regexp.Regexp) ([]UnitStatus, error)
+
+	// GetStatusWithMatcher returns a []UnitStatus, with an element for
+	// each unit where the given matcher returns true.
+	GetStatusWithMatcher(func(string) bool) ([]UnitStatus, error)
 }
 
 // NewFleet creates a new Fleet that is configured with the given settings.


### PR DESCRIPTION
…ices, not all slices
- Adds the `formicactl start <group>` command. Also `formicactl start <group>@<slice> [<group>@<slice2> [...]]` is supported due to the next step
- Added slice support to controller actions `Start`, `Stop`, `Destroy`, `GetStatus`

TODOs
- [x] Add unit tests for slice matching
- [x] Print success message
- [x] Add tests for controller start logic
## Example

```
core@core-01 ~ $ ./formicactl status demo
Group  Units                FDState  FCState  SAState   IP            Machine

demo   demo-main@1.service  loaded   loaded   inactive  172.17.8.101  4ea5734c9d6347829d9236502b79c6ca
demo   demo-main@2.service  loaded   loaded   inactive  172.17.8.102  52f3c1e0193243d8aedbf54052f83c84
core@core-01 ~ $ ./formicactl start demo@1
core@core-01 ~ $ ./formicactl status demo
Group  Units                FDState   FCState   SAState   IP            Machine

demo   demo-main@1.service  launched  launched  inactive  172.17.8.101  4ea5734c9d6347829d9236502b79c6ca
demo   demo-main@2.service  loaded    loaded    inactive  172.17.8.102  52f3c1e0193243d8aedbf54052f83c84
core@core-01 ~ $ ./formicactl status demo
Group  Units                FDState   FCState   SAState   IP            Machine

demo   demo-main@1.service  launched  launched  active    172.17.8.101  4ea5734c9d6347829d9236502b79c6ca
demo   demo-main@2.service  loaded    loaded    inactive  172.17.8.102  52f3c1e0193243d8aedbf54052f83c84
```
