### PR TITLE
formicactl: Add stop and destroy command

### DIFF
--- a/cli/destroy.go
+++ b/cli/destroy.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	destroyCmd = &cobra.Command{
+		Use:   "destroy [group [group..]]",
+		Short: "Destroys the specified group or slices",
+		Long:  "Destroys a group or the specified slices",
+		Run:   destroyRun,
+	}
+)
+
+func destroyRun(cmd *cobra.Command, args []string) {
+	req, err := createRequest(args)
+	if err != nil {
+		fmt.Printf("%#v\n", maskAny(err))
+		os.Exit(1)
+	}
+
+	err = newController.Destroy(req)
+	if err != nil {
+		fmt.Printf("%#v\n", maskAny(err))
+		os.Exit(1)
+	}
+
+	if req.SliceIDs == nil {
+		fmt.Printf("Destroyed group '%s'\n", req.Group)
+	} else if len(req.SliceIDs) == 0 {
+		fmt.Printf("Destroyed all slices of group '%s'\n", req.Group)
+	} else {
+		fmt.Printf("Destroyed %d slices for group '%s': %v", len(req.SliceIDs), req.Group, req.SliceIDs)
+	}
+}

--- a/cli/formicactl.go
+++ b/cli/formicactl.go
@@ -58,6 +58,8 @@ func init() {
 	MainCmd.AddCommand(submitCmd)
 	MainCmd.AddCommand(statusCmd)
 	MainCmd.AddCommand(startCmd)
+	MainCmd.AddCommand(stopCmd)
+	MainCmd.AddCommand(destroyCmd)
 }
 
 func mainRun(cmd *cobra.Command, args []string) {

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	stopCmd = &cobra.Command{
+		Use:   "stop [group [group..]]",
+		Short: "Stops the specified group or slices",
+		Long:  "Stops a group or the specified slices",
+		Run:   stopRun,
+	}
+)
+
+func stopRun(cmd *cobra.Command, args []string) {
+	req, err := createRequest(args)
+	if err != nil {
+		fmt.Printf("%#v\n", maskAny(err))
+		os.Exit(1)
+	}
+
+	err = newController.Stop(req)
+	if err != nil {
+		fmt.Printf("%#v\n", maskAny(err))
+		os.Exit(1)
+	}
+
+	if req.SliceIDs == nil {
+		fmt.Printf("Stopped group '%s'\n", req.Group)
+	} else if len(req.SliceIDs) == 0 {
+		fmt.Printf("Stopped all slices of group '%s'\n", req.Group)
+	} else {
+		fmt.Printf("Stopped %d slices for group '%s': %v", len(req.SliceIDs), req.Group, req.SliceIDs)
+	}
+}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -312,6 +312,70 @@ func TestController_Start(t *testing.T) {
 	mock.AssertExpectationsForObjects(t, fleetMock.Mock)
 }
 
+
+func TestController_Destroy(t *testing.T) {
+	RegisterTestingT(t)
+
+	// Mocks
+	controller, fleetMock := GivenController()
+	fleetMock.On("GetStatusWithMatcher", mock.AnythingOfType("func(string) bool")).Return(
+		[]fleet.UnitStatus{
+			{
+				Name: "test-main@1.service",
+			},
+			{
+				Name: "test-sidekick@1.service",
+			},
+		},
+		nil,
+	).Once()
+	fleetMock.On("Destroy", "test-main@1.service").Return(nil).Once()
+	fleetMock.On("Destroy", "test-sidekick@1.service").Return(nil).Once()
+
+	// Execute test
+	req := Request{
+		Group:    "test",
+		SliceIDs: []string{"1"},
+	}
+	err := controller.Destroy(req)
+
+	// Assert
+	Expect(err).To(BeNil())
+	mock.AssertExpectationsForObjects(t, fleetMock.Mock)
+}
+
+
+func TestController_Stop(t *testing.T) {
+	RegisterTestingT(t)
+
+	// Mocks
+	controller, fleetMock := GivenController()
+	fleetMock.On("GetStatusWithMatcher", mock.AnythingOfType("func(string) bool")).Return(
+		[]fleet.UnitStatus{
+			{
+				Name: "test-main@1.service",
+			},
+			{
+				Name: "test-sidekick@1.service",
+			},
+		},
+		nil,
+	).Once()
+	fleetMock.On("Stop", "test-main@1.service").Return(nil).Once()
+	fleetMock.On("Stop", "test-sidekick@1.service").Return(nil).Once()
+
+	// Execute test
+	req := Request{
+		Group:    "test",
+		SliceIDs: []string{"1"},
+	}
+	err := controller.Stop(req)
+
+	// Assert
+	Expect(err).To(BeNil())
+	mock.AssertExpectationsForObjects(t, fleetMock.Mock)
+}
+
 func TestController_Status_ErrorOnMismatchingSliceIDs(t *testing.T) {
 	RegisterTestingT(t)
 


### PR DESCRIPTION
This PR adds the stop and destroy command. Its actually a copy and paste of the `formicactl start` command.

I guess #28 becomes more interesting with this, as a destroy on a running group may leave artifacts.
