### PR TITLE
expand status in verbose mode

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -139,9 +139,12 @@ func createStatus(group string, usl controller.UnitStatusList) ([]string, error)
 		"",
 	}
 
-	usl, err := usl.Group()
-	if err != nil {
-		return nil, maskAny(err)
+	if !globalFlags.Verbose {
+		var err error
+		usl, err = usl.Group()
+		if err != nil {
+			return nil, maskAny(err)
+		}
 	}
 
 	for _, us := range usl {

--- a/cli/formicactl.go
+++ b/cli/formicactl.go
@@ -16,6 +16,7 @@ import (
 var (
 	globalFlags struct {
 		FleetEndpoint string
+		Verbose       bool
 	}
 
 	newController controller.Controller
@@ -54,6 +55,7 @@ var (
 
 func init() {
 	MainCmd.PersistentFlags().StringVar(&globalFlags.FleetEndpoint, "fleet-endpoint", "unix:///var/run/fleet.sock", "endpoint used to connect to fleet")
+	MainCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "v", false, "verbose output or not")
 
 	MainCmd.AddCommand(submitCmd)
 	MainCmd.AddCommand(statusCmd)


### PR DESCRIPTION
``` bash
# normal status
core@core-01 ~ $ ./formicactl status units@{1..3}
Group    Units                FDState   FCState   SAState   IP              Machine

units@1  *                    loaded    loaded    inactive  192.168.33.102  b25ded3e1a944b9bb5a91124f55f1662
units@2  units_one@2.service  launched  launched  active    192.168.33.103  027494415d6848078626e57fff3cf801
units@2  units_two@2.service  loaded    loaded    inactive  192.168.33.102  b25ded3e1a944b9bb5a91124f55f1662
units@3  *                    loaded    loaded    inactive  192.168.33.102  b25ded3e1a944b9bb5a91124f55f1662

# verbose expands status
core@core-01 ~ $ ./formicactl status units@{1..3} -v
Group    Units                FDState   FCState   SAState   IP              Machine

units@1  units_one@1.service  loaded    loaded    inactive  192.168.33.102  b25ded3e1a944b9bb5a91124f55f1662
units@2  units_one@2.service  launched  launched  active    192.168.33.103  027494415d6848078626e57fff3cf801
units@3  units_one@3.service  loaded    loaded    inactive  192.168.33.102  b25ded3e1a944b9bb5a91124f55f1662
units@1  units_two@1.service  loaded    loaded    inactive  192.168.33.103  027494415d6848078626e57fff3cf801
units@2  units_two@2.service  loaded    loaded    inactive  192.168.33.102  b25ded3e1a944b9bb5a91124f55f1662
units@3  units_two@3.service  loaded    loaded    inactive  192.168.33.103  027494415d6848078626e57fff3cf801
```

RFR @zeisss @JosephSalisbury 
