### PR TITLE
Add golint to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 - wget https://downloads.giantswarm.io/builder/0.11.0/builder
 - chmod +x ./builder
 - export PATH=$PATH:$PWD
+- go get -u github.com/golang/lint/golint
 
 script:
 - make lint

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,8 @@ test: $(SOURCE) VERSION .gobuild
 	    $(TEST_COMMAND)
 
 lint:
-	for source_file in $(SOURCE); do \
-		go vet -x $$source_file ; \
-	done
+	go vet -x ./...
+	golint ./...
 
 ci-build: $(SOURCE) VERSION .gobuild
 	echo Building for $(GOOS)/$(GOARCH)


### PR DESCRIPTION
Related to https://github.com/giantswarm/formica/issues/38

This adds `golint` to the build process, meaning that we can inspect its output as part of the PR process. Note - `golint` will not fail the build if it finds anything.
