### PR TITLE
*: Fix handling of group instances

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/juju/errgo"
 	"github.com/giantswarm/formica/fleet"
 	"github.com/giantswarm/formica/task"
 )
@@ -145,7 +146,7 @@ func (r Request) ExtendSlices() (Request, error) {
 
 func (c controller) Submit(req Request) (*task.TaskObject, error) {
 	if (len(req.Units) == 0) {
-		return nil, maskAny(illegalArgumentError)
+		return nil, errgo.WithCausef(nil, maskAny(invalidArgumentError) , "invalid argument: Units must not be empty")
 	}
 	action := func() error {
 		extended, err := req.ExtendSlices()

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -124,6 +124,9 @@ var unitExp = regexp.MustCompile("@.service")
 // 	 bar@2.service
 //
 func (r Request) ExtendSlices() (Request, error) {
+	if len(r.SliceIDs) == 0 {
+		return r, nil
+	}
 	newRequest := Request{
 		SliceIDs: r.SliceIDs,
 		Units:    []Unit{},
@@ -141,6 +144,9 @@ func (r Request) ExtendSlices() (Request, error) {
 }
 
 func (c controller) Submit(req Request) (*task.TaskObject, error) {
+	if (len(req.Units) == 0) {
+		return nil, maskAny(illegalArgumentError)
+	}
 	action := func() error {
 		extended, err := req.ExtendSlices()
 		if err != nil {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -131,12 +131,47 @@ func Test_Request_ExtendSlices(t *testing.T) {
 				},
 			},
 		},
+
+		// This test ensures we generate the correct units for group instances,
+		// so groups that do not want slices.
+		{
+			Input: Request{
+				SliceIDs: nil,
+				Units: []Unit{
+					{
+						Name:    "single-1.service",
+						Content: "some unit content",
+					},
+					{
+						Name:    "single-2.service",
+						Content: "some unit content",
+					},
+				},
+			},
+			Expected: Request{
+				SliceIDs: nil,
+				Units: []Unit{
+					{
+						Name:    "single-1.service",
+						Content: "some unit content",
+					},
+					{
+						Name:    "single-2.service",
+						Content: "some unit content",
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
 		output, err := testCase.Input.ExtendSlices()
 		if err != nil {
 			t.Fatalf("Request.ExtendSlices returned error: %#v", err)
+		}
+
+		if len(output.Units) != len(testCase.Expected.Units) {
+			t.Fatalf("Number of units in expected output differed from received units: %d != %d", len(output.Units), len(testCase.Expected.Units))
 		}
 
 		for i, outputUnit := range output.Units {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -322,6 +322,27 @@ func GivenController() (Controller, *fleetMock) {
 	return NewController(cfg), &fleetMock
 }
 
+func TestController_Submit_Error(t *testing.T) {
+	RegisterTestingT(t)
+
+	controller, fleetMock := GivenController()
+
+	// Execute
+	req := Request{
+		Group: "single",
+		SliceIDs: nil,
+		Units: []Unit{}, // Intentionally left empty!
+	}
+
+	task, err := controller.Submit(req)
+
+	// Assert
+	Expect(task).To(BeNil())
+	Expect(err).To(HaveOccurred())
+	Expect(err.Error()).To(Equal("invalid argument: Units must not be empty"))
+	mock.AssertExpectationsForObjects(t, fleetMock.Mock)
+}
+
 func TestController_Start(t *testing.T) {
 	RegisterTestingT(t)
 

--- a/controller/error.go
+++ b/controller/error.go
@@ -54,10 +54,10 @@ func IsInvalidUnitStatus(err error) bool {
 }
 
 
-var illegalArgumentError = errgo.Newf("illegal argument")
+var invalidArgumentError = errgo.Newf("invalid argument")
 
-// IsIllegalArgument checks whether the given error indicates a invalid argument
+// IsInvalidArgument checks whether the given error indicates a invalid argument
 // to the operation that was performed.
-func IsIllegalArgument(err error) bool {
-	return errgo.Cause(err) == illegalArgumentError
+func IsInvalidArgument(err error) bool {
+	return errgo.Cause(err) == invalidArgumentError
 }

--- a/controller/error.go
+++ b/controller/error.go
@@ -52,3 +52,12 @@ var invalidUnitStatusError = errgo.New("invalid unit status")
 func IsInvalidUnitStatus(err error) bool {
 	return errgo.Cause(err) == invalidUnitStatusError
 }
+
+
+var illegalArgumentError = errgo.Newf("illegal argument")
+
+// IsIllegalArgument checks whether the given error indicates a invalid argument
+// to the operation that was performed.
+func IsIllegalArgument(err error) bool {
+	return errgo.Cause(err) == illegalArgumentError
+}


### PR DESCRIPTION
As discussed for https://github.com/giantswarm/giantswarm/issues/518 I played around with a non-group slices group and failed to get it working. This PR fixes it:

```
core@core-01 ~ $ ls single/
single-2.service  single.service

core@core-01 ~ $ ./formicactl submit single
Succeeded to submit all slices of group 'single'.
core@core-01 ~ $ ./formicactl status single
Group  Units  FDState  FCState  SAState  IP  Machine

core@core-01 ~ $ ./formicactl status single
Group   Units  FDState  FCState  SAState   IP            Machine

single  *      loaded   loaded   inactive  172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl status single
Group   Units  FDState  FCState  SAState   IP            Machine

single  *      loaded   loaded   inactive  172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl status -v single
Group   Units             FDState  FCState  SAState   IP            Machine

single  single-2.service  loaded   loaded   inactive  172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
single  single.service    loaded   loaded   inactive  172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl start single
Succeeded to start all slices of group 'single'.
core@core-01 ~ $ ./formicactl status -v single
Group   Units             FDState   FCState   SAState  IP            Machine

single  single-2.service  launched  launched  active   172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
single  single.service    launched  launched  active   172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl status -v single
Group   Units             FDState   FCState   SAState  IP            Machine

single  single-2.service  launched  launched  active   172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
single  single.service    launched  launched  active   172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl status single
Group   Units  FDState   FCState   SAState  IP            Machine

single  *      launched  launched  active   172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl stop single
Succeeded to stop all slices of group 'single'.
core@core-01 ~ $ ./formicactl status single
Group   Units  FDState  FCState  SAState   IP            Machine

single  *      loaded   loaded   inactive  172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl status -v single
Group   Units             FDState  FCState  SAState   IP            Machine

single  single-2.service  loaded   loaded   inactive  172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
single  single.service    loaded   loaded   inactive  172.17.8.103  99f23dbedf2f4bdd9ed9f2600b5944c3
core@core-01 ~ $ ./formicactl destroy single
Succeeded to destroy all slices of group 'single'.
core@core-01 ~ $ fleetctl list-unit-files
UNIT            HASH    DSTATE      STATE       TARGET
demo-main@1.service fa59254 launched    launched    52f3c1e0.../172.17.8.102
demo-main@2.service fa59254 launched    launched    52f3c1e0.../172.17.8.102
```

ping @giantswarm/cena 

Fixes https://github.com/giantswarm/giantswarm/issues/518

<!---
@huboard:{"custom_state":"archived"}
-->
