### PR TITLE
*: Fixed various go vet and golint warnings

### DIFF
--- a/cli/formicactl.go
+++ b/cli/formicactl.go
@@ -1,4 +1,4 @@
-// Package formicactl implements a command line client for formica. Cobra CLI
+// Package cli implements a command line client for formica. Cobra CLI
 // is used as framework.
 package cli
 
@@ -24,6 +24,7 @@ var (
 	newFileSystem filesystemspec.FileSystem
 	newFleet      fleet.Fleet
 
+	// MainCmd contains the cobra.Command to execute formicactl.
 	MainCmd = &cobra.Command{
 		Use:   "formicactl",
 		Short: "orchestrate groups of unit files on Fleet clusters",

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -307,16 +307,16 @@ func Test_matchesGroupSlices(t *testing.T) {
 	}
 }
 
-// GivenController returns a controller where the fleet backend is replaced
+// givenController returns a controller where the fleet backend is replaced
 // with a mock.
-func GivenController() (Controller, *fleetMock) {
+func givenController() (Controller, *fleetMock) {
 	fleetMock := fleetMock{}
 
-	newTaskServiceConfig := task.DefaultTaskServiceConfig()
+	newTaskServiceConfig := task.DefaultConfig()
 	newTaskService := task.NewTaskService(newTaskServiceConfig)
 
 	cfg := Config{
-		Fleet:       &fleetMock,
+		Fleet:   &fleetMock,
 		TaskService: newTaskService,
 	}
 	return NewController(cfg), &fleetMock
@@ -325,7 +325,7 @@ func GivenController() (Controller, *fleetMock) {
 func TestController_Submit_Error(t *testing.T) {
 	RegisterTestingT(t)
 
-	controller, fleetMock := GivenController()
+	controller, fleetMock := givenController()
 
 	// Execute
 	req := Request{
@@ -347,7 +347,7 @@ func TestController_Start(t *testing.T) {
 	RegisterTestingT(t)
 
 	// Mocks
-	controller, fleetMock := GivenController()
+	controller, fleetMock := givenController()
 	fleetMock.On("GetStatusWithMatcher", mock.AnythingOfType("func(string) bool")).Return(
 		[]fleet.UnitStatus{
 			{
@@ -381,7 +381,7 @@ func TestController_Destroy(t *testing.T) {
 	RegisterTestingT(t)
 
 	// Mocks
-	controller, fleetMock := GivenController()
+	controller, fleetMock := givenController()
 	fleetMock.On("GetStatusWithMatcher", mock.AnythingOfType("func(string) bool")).Return(
 		[]fleet.UnitStatus{
 			{
@@ -415,7 +415,7 @@ func TestController_Stop(t *testing.T) {
 	RegisterTestingT(t)
 
 	// Mocks
-	controller, fleetMock := GivenController()
+	controller, fleetMock := givenController()
 	fleetMock.On("GetStatusWithMatcher", mock.AnythingOfType("func(string) bool")).Return(
 		[]fleet.UnitStatus{
 			{
@@ -449,7 +449,7 @@ func TestController_Status_ErrorOnMismatchingSliceIDs(t *testing.T) {
 	RegisterTestingT(t)
 
 	// Mocks
-	controller, fleetMock := GivenController()
+	controller, fleetMock := givenController()
 	fleetMock.On("GetStatusWithMatcher", mock.AnythingOfType("func(string) bool")).Return(
 		[]fleet.UnitStatus{
 			{

--- a/controller/status.go
+++ b/controller/status.go
@@ -7,8 +7,11 @@ import (
 	"github.com/giantswarm/formica/fleet"
 )
 
+// UnitStatusList represents a list of UnitStatus.
 type UnitStatusList []fleet.UnitStatus
 
+// Group returns a shortened version of usl where equal status
+// are replaced by one UnitStatus where the Name is replaced with "*".
 func (usl UnitStatusList) Group() ([]fleet.UnitStatus, error) {
 	matchers := map[string]struct{}{}
 	newList := []fleet.UnitStatus{}

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -22,7 +22,7 @@ func TestDefaultConfig(t *testing.T) {
 	Expect(cfg.Client).To(Not(BeZero()))
 }
 
-func GivenMockedFleet() (*fleetClientMock, *fleet) {
+func givenMockedFleet() (*fleetClientMock, *fleet) {
 	mock := &fleetClientMock{}
 	return mock, &fleet{
 		Client: mock,
@@ -30,8 +30,8 @@ func GivenMockedFleet() (*fleetClientMock, *fleet) {
 	}
 }
 
-func GivenMockedFleetWithMachines(machines []machine.MachineState) (*fleetClientMock, *fleet) {
-	fleetClientMock, fleet := GivenMockedFleet()
+func givenMockedFleetWithMachines(machines []machine.MachineState) (*fleetClientMock, *fleet) {
+	fleetClientMock, fleet := givenMockedFleet()
 	fleetClientMock.On("Machines").Return(machines, nil)
 	return fleetClientMock, fleet
 }
@@ -39,7 +39,7 @@ func GivenMockedFleetWithMachines(machines []machine.MachineState) (*fleetClient
 func TestFleetSubmit_Success(t *testing.T) {
 	RegisterTestingT(t)
 
-	fleetClientMock, fleet := GivenMockedFleet()
+	fleetClientMock, fleet := givenMockedFleet()
 	fleetClientMock.On("CreateUnit", mock.AnythingOfType("*schema.Unit")).Once().Return(nil, nil)
 	err := fleet.Submit("unit.service", "[Unit]\n"+
 		"Description=This is a test unit\n"+
@@ -61,7 +61,7 @@ func TestFleetSubmit_Success(t *testing.T) {
 func TestFleetStart_Success(t *testing.T) {
 	RegisterTestingT(t)
 
-	mock, fleet := GivenMockedFleet()
+	mock, fleet := givenMockedFleet()
 	mock.On("SetUnitTargetState", "unit.service", unitStateLaunched).Once().Return(nil)
 
 	err := fleet.Start("unit.service")
@@ -73,7 +73,7 @@ func TestFleetStart_Success(t *testing.T) {
 func TestFleetStop_Success(t *testing.T) {
 	RegisterTestingT(t)
 
-	mock, fleet := GivenMockedFleet()
+	mock, fleet := givenMockedFleet()
 	mock.On("SetUnitTargetState", "unit.service", unitStateLoaded).Once().Return(nil)
 	err := fleet.Stop("unit.service")
 
@@ -84,7 +84,7 @@ func TestFleetStop_Success(t *testing.T) {
 func TestFleetDestroy_Success(t *testing.T) {
 	RegisterTestingT(t)
 
-	mock, fleet := GivenMockedFleet()
+	mock, fleet := givenMockedFleet()
 	mock.On("DestroyUnit", "unit.service").Once().Return(nil)
 	err := fleet.Destroy("unit.service")
 
@@ -99,7 +99,7 @@ func TestFleetGetStatusWithMatcher__Success(t *testing.T) {
 	RegisterTestingT(t)
 
 	// Mocking
-	fleetClientMock, fleet := GivenMockedFleet()
+	fleetClientMock, fleet := givenMockedFleet()
 	fleetClientMock.On("Units").Return([]*schema.Unit{
 		{Name: "unit.service", CurrentState: unitStateLaunched, DesiredState: unitStateLaunched},
 		{Name: "other.service", CurrentState: unitStateInactive, DesiredState: unitStateInactive},
@@ -219,7 +219,7 @@ func Test_Fleet_createOurStatusList(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		_, fleet := GivenMockedFleet()
+		_, fleet := givenMockedFleet()
 		ourStatusList, err := fleet.createOurStatusList(testCase.FoundFleetUnits, testCase.FoundFleetUnitStates, testCase.FleetMachines)
 		if err != nil {
 			t.Fatalf("Fleet.createOurStatusList returned error: %#v", err)

--- a/task/memory_storage.go
+++ b/task/memory_storage.go
@@ -9,7 +9,7 @@ import (
 func NewMemoryStorage() Storage {
 	newStorage := &memoryStorage{
 		Mutex:   sync.Mutex{},
-		Storage: map[string]TaskObject{},
+		Storage: map[string]Task{},
 	}
 
 	return newStorage
@@ -17,10 +17,10 @@ func NewMemoryStorage() Storage {
 
 type memoryStorage struct {
 	Mutex   sync.Mutex
-	Storage map[string]TaskObject
+	Storage map[string]Task
 }
 
-func (mb *memoryStorage) Get(taskID string) (*TaskObject, error) {
+func (mb *memoryStorage) Get(taskID string) (*Task, error) {
 	mb.Mutex.Lock()
 	defer mb.Mutex.Unlock()
 
@@ -31,7 +31,7 @@ func (mb *memoryStorage) Get(taskID string) (*TaskObject, error) {
 	return nil, maskAny(taskObjectNotFoundError)
 }
 
-func (mb *memoryStorage) Set(taskObject *TaskObject) error {
+func (mb *memoryStorage) Set(taskObject *Task) error {
 	mb.Mutex.Lock()
 	defer mb.Mutex.Unlock()
 

--- a/task/memory_storage_test.go
+++ b/task/memory_storage_test.go
@@ -14,7 +14,7 @@ func Test_Task_Storage_Memory(t *testing.T) {
 		t.Fatalf("Storage.Get did NOT return proper error")
 	}
 
-	taskObject := &TaskObject{
+	taskObject := &Task{
 		ID: taskID,
 	}
 

--- a/task/status.go
+++ b/task/status.go
@@ -4,7 +4,9 @@ package task
 type ActiveStatus string
 
 const (
+	// StatusStarted represents a running task
 	StatusStarted ActiveStatus = "started"
+	// StatusStopped represents a stopped task, that has not been started yet
 	StatusStopped ActiveStatus = "stopped"
 )
 
@@ -13,13 +15,15 @@ const (
 type FinalStatus string
 
 const (
+	// StatusFailed represents a task where the action return an error.
 	StatusFailed    FinalStatus = "failed"
+	// StatusSucceeded represents a task where the action returned nil.
 	StatusSucceeded FinalStatus = "succeeded"
 )
 
 // HasFailedStatus determines whether a task has failed or not. Note that this
 // is about a final status.
-func HasFailedStatus(taskObject *TaskObject) bool {
+func HasFailedStatus(taskObject *Task) bool {
 	if taskObject.ActiveStatus == StatusStopped && taskObject.FinalStatus == StatusFailed {
 		return true
 	}
@@ -28,7 +32,7 @@ func HasFailedStatus(taskObject *TaskObject) bool {
 }
 
 // HasFinalStatus determines whether a task has a final status or not.
-func HasFinalStatus(taskObject *TaskObject) bool {
+func HasFinalStatus(taskObject *Task) bool {
 	if HasFailedStatus(taskObject) || HasSucceededStatus(taskObject) {
 		return true
 	}
@@ -38,7 +42,7 @@ func HasFinalStatus(taskObject *TaskObject) bool {
 
 // HasSucceededStatus determines whether a task has succeeded or not. Note that
 // this is about a final status.
-func HasSucceededStatus(taskObject *TaskObject) bool {
+func HasSucceededStatus(taskObject *Task) bool {
 	if taskObject.ActiveStatus == StatusStopped && taskObject.FinalStatus == StatusSucceeded {
 		return true
 	}

--- a/task/status_test.go
+++ b/task/status_test.go
@@ -6,12 +6,12 @@ import (
 
 func Test_Task_Status_HasFinalStatus(t *testing.T) {
 	testCases := []struct {
-		Input    *TaskObject
+		Input    *Task
 		Expected bool
 	}{
 		// This status combination is invalid.
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStarted,
 				Error:        "",
 				FinalStatus:  StatusFailed,
@@ -21,7 +21,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 		},
 
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStopped,
 				Error:        "",
 				FinalStatus:  StatusFailed,
@@ -32,7 +32,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 
 		// This status combination is invalid.
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStarted,
 				Error:        "",
 				FinalStatus:  StatusSucceeded,
@@ -41,7 +41,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 			Expected: false,
 		},
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStopped,
 				Error:        "",
 				FinalStatus:  StatusSucceeded,
@@ -50,7 +50,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 			Expected: true,
 		},
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStarted,
 				Error:        "",
 				FinalStatus:  "",
@@ -59,7 +59,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 			Expected: false,
 		},
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStopped,
 				Error:        "",
 				FinalStatus:  "",
@@ -68,7 +68,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 			Expected: false,
 		},
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStarted,
 				Error:        "",
 				FinalStatus:  "",
@@ -77,7 +77,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 			Expected: false,
 		},
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStopped,
 				Error:        "",
 				FinalStatus:  "",
@@ -87,7 +87,7 @@ func Test_Task_Status_HasFinalStatus(t *testing.T) {
 		},
 
 		{
-			Input: &TaskObject{
+			Input: &Task{
 				ActiveStatus: StatusStopped,
 				Error:        "test error",
 				FinalStatus:  "",

--- a/task/storage.go
+++ b/task/storage.go
@@ -3,8 +3,8 @@ package task
 // Storage represents some storage solution to persist task objects.
 type Storage interface {
 	// Get fetches the corresponding task object for the given task ID.
-	Get(taskID string) (*TaskObject, error)
+	Get(taskID string) (*Task, error)
 
 	// Set persists the given task object for its corresponding task ID.
-	Set(taskObject *TaskObject) error
+	Set(taskObject *Task) error
 }

--- a/task/task_service_test.go
+++ b/task/task_service_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_Task_TaskService_Create_Success(t *testing.T) {
-	newTaskService := NewTaskService(DefaultTaskServiceConfig())
+	newTaskService := NewTaskService(DefaultConfig())
 
 	testData := "invalid"
 
@@ -40,7 +40,7 @@ func Test_Task_TaskService_Create_Success(t *testing.T) {
 }
 
 func Test_Task_TastService_Create_Error(t *testing.T) {
-	newConfig := DefaultTaskServiceConfig()
+	newConfig := DefaultConfig()
 	newConfig.WaitSleep = 10 * time.Millisecond
 	newTaskService := NewTaskService(newConfig)
 
@@ -68,7 +68,7 @@ func Test_Task_TastService_Create_Error(t *testing.T) {
 }
 
 func Test_Task_TastService_Create_FetchState(t *testing.T) {
-	newConfig := DefaultTaskServiceConfig()
+	newConfig := DefaultConfig()
 	newConfig.WaitSleep = 10 * time.Millisecond
 	newTaskService := NewTaskService(newConfig)
 
@@ -108,7 +108,7 @@ func Test_Task_TastService_Create_FetchState(t *testing.T) {
 }
 
 func Test_Task_TastService_Create_Wait(t *testing.T) {
-	newConfig := DefaultTaskServiceConfig()
+	newConfig := DefaultConfig()
 	newConfig.WaitSleep = 10 * time.Millisecond
 	newTaskService := NewTaskService(newConfig)
 


### PR DESCRIPTION
Fixes #38. These are only renames done by `gofmt` and a few manualy reverts, e.g. to keep `TaskService` inside the `Controller` for the field name.
