### PR TITLE
Fleet http endpoint fix

### DIFF
--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -39,7 +39,7 @@ func DefaultConfig() Config {
 	}
 
 	newConfig := Config{
-		Client:   http.DefaultClient,
+		Client:   &http.Client{},
 		Endpoint: *URL,
 	}
 

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -72,7 +72,7 @@ func Test_Fleet_DefaultConfig_Failure_003(t *testing.T) {
 	Expect(newCfg.Endpoint).To(Not(BeZero()))
 	Expect(newCfg.Client).To(Not(BeZero()))
 
-	Expect(oldCfg.Client).ToNot(Equal(newCfg.Client))
+	Expect(oldCfg.Client).ToNot(BeIdenticalTo(newCfg.Client))
 }
 
 func givenMockedFleet() (*fleetClientMock, *fleet) {

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -59,6 +59,22 @@ func Test_Fleet_DefaultConfig_Failure_002(t *testing.T) {
 	Expect(IsInvalidEndpoint(err)).To(BeTrue())
 }
 
+// Test_Fleet_DefaultConfig_Failure_003 verifies that the new config
+// sets a new http client and does not overwrite the old one.
+func Test_Fleet_DefaultConfig_Failure_003(t *testing.T) {
+	RegisterTestingT(t)
+
+	oldCfg := DefaultConfig()
+	Expect(oldCfg.Endpoint).To(Not(BeZero()))
+	Expect(oldCfg.Client).To(Not(BeZero()))
+
+	newCfg := DefaultConfig()
+	Expect(newCfg.Endpoint).To(Not(BeZero()))
+	Expect(newCfg.Client).To(Not(BeZero()))
+
+	Expect(oldCfg.Client).ToNot(Equal(newCfg.Client))
+}
+
 func givenMockedFleet() (*fleetClientMock, *fleet) {
 	mock := &fleetClientMock{}
 	return mock, &fleet{


### PR DESCRIPTION
see #63 
the fleet DefaultConfig() func overwrites the underlying client struct. This caused problems when using the --fleet-endpoint flag:
- [inagoctl]: DefaultConfig()
- set config.url
- create fleet client
- create controller default config
- [controller]: create fleet default config
- create fleet client
- [inagoctl]: set controller.Fleet to oldFleet
  => error: underliying http client was overwritten by second fleet default config call.

This branch provides a test and a fix.

<!---
@huboard:{"custom_state":"archived"}
-->
