### PR TITLE
Vagrant refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ ci-test: $(SOURCE) VERSION .gobuild
 # Set fleet endpoint to a fleet API endpoint available to the container.
 int-test: $(BIN) $(INT_TESTS)
 	@echo Running integration tests
+	@echo Creating CoreOS integration test machine user-data
+	cp $(VAGRANT_PATH)/user-data.sample $(VAGRANT_PATH)/user-data
 	@echo Starting CoreOS integration test machine
 	cd $(VAGRANT_PATH) && vagrant up
 	sleep 10
@@ -104,3 +106,5 @@ int-test: $(BIN) $(INT_TESTS)
 		-v $(INT_TESTS_PATH)
 	@echo Destroying the integration test machine
 	cd $(VAGRANT_PATH) && vagrant destroy -f
+	@echo Removing test machine user-data
+	rm $(VAGRANT_PATH)/user-data

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ ci-test: $(SOURCE) VERSION .gobuild
 	
 # Use with `GOOS=linux FLEET_ENDPOINT=http://192.168.99.1:49153/ make int-test`
 # Set fleet endpoint to a fleet API endpoint available to the container.
+
+# With the dash before docker we don't exit if the 'docker run' returns with
+# an error and run the rest of the target definition. Why? We want to destroy
+# the test machine in any case.
 int-test: $(BIN) $(INT_TESTS)
 	@echo Running integration tests
 	@echo Creating CoreOS integration test machine user-data
@@ -93,9 +97,6 @@ int-test: $(BIN) $(INT_TESTS)
 	@echo Starting CoreOS integration test machine
 	cd $(VAGRANT_PATH) && vagrant up
 	sleep 10
-	# With the dash before docker we don't exit if the 'docker run' returns with
-	# an error and run the rest of the target definition. Why? We want to destroy
-	# the test machine in any case.
 	-docker run \
 		--rm \
 		-ti \

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ make target `int-test`, so you don't need to start a machine yourself.
 
 ### Integration Test Machine Configuration
 
-1. Copy `inago/int-tests/vagrant/user-data.sample` to `inago/int-tests/vagrant/user-data`.
-	- *config.rb overwrites the discovery token every time you start a machine, so we can't add a user-data file to github.*
-2. Set the `FLEET_ENDPOINT` environment variable to IP listed under the vboxnet
+Set the `FLEET_ENDPOINT` environment variable to IP listed under the vboxnet
 interface of your docker-machine.
 
 ## Further Steps


### PR DESCRIPTION
removes the need to copy the `user-data.sample` to `user-data` by creating a copy before starting the test machine and removing it after the tests are done.

<!---
@huboard:{"custom_state":"archived"}
-->
