### PR TITLE
Move filesystem logic back to cli

### DIFF
--- a/cli/inagoctl.go
+++ b/cli/inagoctl.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/giantswarm/inago/controller"
 	"github.com/giantswarm/inago/file-system/real"
+	"github.com/giantswarm/inago/file-system/spec"
 	"github.com/giantswarm/inago/fleet"
 )
 
@@ -21,6 +22,7 @@ var (
 
 	newController controller.Controller
 	newFleet      fleet.Fleet
+	fs            filesystemspec.FileSystem
 
 	// MainCmd contains the cobra.Command to execute inagoctl.
 	MainCmd = &cobra.Command{
@@ -31,6 +33,7 @@ var (
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// This callback is executed after flags are parsed and before any
 			// command runs.
+			fs = filesystemreal.NewFileSystem()
 
 			URL, err := url.Parse(globalFlags.FleetEndpoint)
 			if err != nil {
@@ -46,7 +49,6 @@ var (
 
 			newControllerConfig := controller.DefaultConfig()
 			newControllerConfig.Fleet = newFleet
-			newControllerConfig.FileSystem = filesystemreal.NewFileSystem()
 			newController = controller.NewController(newControllerConfig)
 		},
 	}

--- a/cli/request.go
+++ b/cli/request.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"path/filepath"
+
+	"github.com/giantswarm/inago/controller"
+	"github.com/giantswarm/inago/file-system/spec"
+)
+
+// readUnitFiles reads the given dir and returns a map of filename => filecontent.
+// If any read operation fails, the error is immediately returned.
+func readUnitFiles(fs filesystemspec.FileSystem, dir string) (map[string]string, error) {
+	fileInfos, err := fs.ReadDir(dir)
+	if err != nil {
+		return nil, maskAny(err)
+	}
+
+	unitFiles := map[string]string{}
+	for _, fileInfo := range fileInfos {
+		if fileInfo.IsDir() {
+			continue
+		}
+
+		raw, err := fs.ReadFile(filepath.Join(dir, fileInfo.Name()))
+		if err != nil {
+			return nil, maskAny(err)
+		}
+
+		unitFiles[fileInfo.Name()] = string(raw)
+	}
+
+	return unitFiles, nil
+}
+
+// extendRequestWithContent reads all unitfiles for the given group and returns
+// a new Request with the Units filled.
+func extendRequestWithContent(fs filesystemspec.FileSystem, req controller.Request) (controller.Request, error) {
+	unitFiles, err := readUnitFiles(fs, req.Group)
+	if err != nil {
+		return controller.Request{}, maskAny(err)
+	}
+	for name, content := range unitFiles {
+		req.Units = append(req.Units, controller.Unit{Name: name, Content: content})
+	}
+
+	return req, nil
+}

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -1,4 +1,4 @@
-package controller
+package cli
 
 import (
 	"os"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/juju/errgo"
 
+	"github.com/giantswarm/inago/controller"
 	"github.com/giantswarm/inago/file-system/fake"
 )
 
@@ -19,8 +20,8 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 	testCases := []struct {
 		Setup    []testFileSystemSetup
 		Error    error
-		Input    Request
-		Expected Request
+		Input    controller.Request
+		Expected controller.Request
 	}{
 		// This test ensures that loading a single unit from a directory results in
 		// the expected controller request.
@@ -33,17 +34,17 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 				},
 			},
 			Error: nil,
-			Input: Request{
-				RequestConfig: RequestConfig{
+			Input: controller.Request{
+				RequestConfig: controller.RequestConfig{
 					Group:    "dirname",
 					SliceIDs: []string{},
 				},
 			},
-			Expected: Request{
-				RequestConfig: RequestConfig{
+			Expected: controller.Request{
+				RequestConfig: controller.RequestConfig{
 					SliceIDs: []string{},
 				},
-				Units: []Unit{
+				Units: []controller.Unit{
 					{
 						Name:    "dirname_unit.service",
 						Content: "some unit content",
@@ -57,8 +58,8 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 		{
 			Setup:    []testFileSystemSetup{},
 			Error:    nil,
-			Input:    Request{},
-			Expected: Request{},
+			Input:    controller.Request{},
+			Expected: controller.Request{},
 		},
 
 		// This test ensures that trying to load unit files when no files are in
@@ -70,13 +71,13 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 				Path: "dirname",
 				Err:  errgo.New("no such file or directory"),
 			},
-			Input: Request{
-				RequestConfig: RequestConfig{
+			Input: controller.Request{
+				RequestConfig: controller.RequestConfig{
 					Group:    "dirname",
 					SliceIDs: []string{},
 				},
 			},
-			Expected: Request{},
+			Expected: controller.Request{},
 		},
 	}
 
@@ -90,11 +91,7 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 			}
 		}
 
-		newControllerConfig := DefaultConfig()
-		newControllerConfig.FileSystem = newFileSystem
-		newController := NewController(newControllerConfig)
-
-		output, err := newController.ExtendWithContent(testCase.Input)
+		output, err := extendRequestWithContent(newFileSystem, testCase.Input)
 		if testCase.Error != nil && err.Error() != testCase.Error.Error() {
 			t.Fatal("case", i+1, "expected", testCase.Error, "got", err)
 		}

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -138,9 +138,15 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 		if len(output.Units) != len(testCase.Expected.Units) {
 			t.Fatalf("case %d: expected %d units in output, got %d", i+1, len(testCase.Expected.Units), len(output.Units))
 		}
-		for j, outputUnit := range output.Units {
-			if outputUnit.Name != testCase.Expected.Units[j].Name {
-				t.Fatalf("case %d: expected %s, got %s", i+1, testCase.Expected.Units[j].Name, outputUnit.Name)
+		for _, outputUnit := range testCase.Expected.Units {
+			found := false
+			for _, expectedUnit := range output.Units {
+				if outputUnit.Name == expectedUnit.Name {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("case %d: expected %s to be in output, not found", i+1, outputUnit.Name)
 			}
 		}
 	}

--- a/cli/submit.go
+++ b/cli/submit.go
@@ -44,7 +44,7 @@ func submitRun(cmd *cobra.Command, args []string) {
 	newRequestConfig.SliceIDs = strings.Split(strings.Repeat("x", scale), "")
 	req := controller.NewRequest(newRequestConfig)
 
-	req, err := newController.ExtendWithContent(req)
+	req, err := extendRequestWithContent(fs, req)
 	if err != nil {
 		fmt.Printf("%#v\n", maskAny(err))
 		os.Exit(1)

--- a/cli/update.go
+++ b/cli/update.go
@@ -44,7 +44,7 @@ func updateRun(cmd *cobra.Command, args []string) {
 	newRequestConfig.Group = group
 	req := controller.NewRequest(newRequestConfig)
 
-	req, err := newController.ExtendWithContent(req)
+	req, err := extendRequestWithContent(fs, req)
 	handleUpdateCmdError(err)
 	req, err = newController.ExtendWithExistingSliceIDs(req)
 	handleUpdateCmdError(err)

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -48,7 +48,7 @@ func validateRun(cmd *cobra.Command, args []string) {
 		newRequestConfig.Group = group
 		request := controller.NewRequest(newRequestConfig)
 
-		request, err := newController.ExtendWithContent(request)
+		request, err := extendRequestWithContent(fs, request)
 		if err != nil {
 			fmt.Printf("%#v\n", maskAny(err))
 			os.Exit(1)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -10,8 +10,6 @@ import (
 	"github.com/coreos/fleet/unit"
 
 	"github.com/giantswarm/inago/common"
-	"github.com/giantswarm/inago/file-system/fake"
-	"github.com/giantswarm/inago/file-system/spec"
 	"github.com/giantswarm/inago/fleet"
 	"github.com/giantswarm/inago/task"
 )
@@ -22,8 +20,6 @@ type Config struct {
 	// Dependencies.
 
 	Fleet fleet.Fleet
-
-	FileSystem filesystemspec.FileSystem
 
 	TaskService task.Service
 
@@ -58,7 +54,6 @@ func DefaultConfig() Config {
 
 	newConfig := Config{
 		Fleet:       newFleet,
-		FileSystem:  filesystemfake.NewFileSystem(),
 		TaskService: newTaskService,
 		WaitCount:   3,
 		WaitSleep:   1 * time.Second,
@@ -71,7 +66,6 @@ func DefaultConfig() Config {
 // Controller defines the interface a controller needs to implement to provide
 // operations for groups of unit files against a fleet cluster.
 type Controller interface {
-	ExtendWithContent(req Request) (Request, error)
 	ExtendWithExistingSliceIDs(req Request) (Request, error)
 	ExtendWithRandomSliceIDs(req Request) (Request, error)
 

--- a/controller/request.go
+++ b/controller/request.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 
 	"github.com/giantswarm/inago/fleet"
@@ -75,29 +74,6 @@ func (r Request) ExtendSlices() (Request, error) {
 	return r, nil
 }
 
-func (c controller) readUnitFiles(dir string) (map[string]string, error) {
-	fileInfos, err := c.FileSystem.ReadDir(dir)
-	if err != nil {
-		return nil, maskAny(err)
-	}
-
-	unitFiles := map[string]string{}
-	for _, fileInfo := range fileInfos {
-		if fileInfo.IsDir() {
-			continue
-		}
-
-		raw, err := c.FileSystem.ReadFile(filepath.Join(dir, fileInfo.Name()))
-		if err != nil {
-			return nil, maskAny(err)
-		}
-
-		unitFiles[fileInfo.Name()] = string(raw)
-	}
-
-	return unitFiles, nil
-}
-
 func (c controller) getExistingSliceIDs(req Request) ([]string, error) {
 	usl, err := c.Fleet.GetStatusWithMatcher(matchesUnitBase(req))
 	if fleet.IsUnitNotFound(err) {
@@ -130,18 +106,6 @@ func (c controller) ExtendWithExistingSliceIDs(req Request) (Request, error) {
 		return Request{}, maskAny(err)
 	}
 	req.SliceIDs = newSliceIDs
-
-	return req, nil
-}
-
-func (c controller) ExtendWithContent(req Request) (Request, error) {
-	unitFiles, err := c.readUnitFiles(req.Group)
-	if err != nil {
-		return Request{}, maskAny(err)
-	}
-	for name, content := range unitFiles {
-		req.Units = append(req.Units, Unit{Name: name, Content: content})
-	}
 
 	return req, nil
 }


### PR DESCRIPTION
This puts the logic to read the unit files for submit/update/validate into the client. In case the controller is separated from the CLI, there is no way for the controller to access the FS of the cli and would always need to upload the files to the controller. 

To not move us into a confusing situation that the same package reads files, gives them to a client which then passes them back (which someone could obviously see as a point of opzimization to just do direct), I would put this responsibility back to the cli package. It might make sense to move this into a subpackage though. Not sure.

<!---
@huboard:{"custom_state":"archived"}
-->
