### PR TITLE
Adds DesiredSlices to Request to define number of slices when submitting

### DIFF
--- a/cli/submit.go
+++ b/cli/submit.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/giantswarm/inago/controller"
+	"github.com/giantswarm/inago/file-system/spec"
+	"github.com/juju/errgo"
 )
 
 var (
@@ -38,17 +40,7 @@ func submitRun(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	newRequestConfig := controller.DefaultRequestConfig()
-	newRequestConfig.Group = group
-	newRequestConfig.SliceIDs = strings.Split(strings.Repeat("x", scale), "")
-	req := controller.NewRequest(newRequestConfig)
-
-	req, err := extendRequestWithContent(fs, req)
-	if err != nil {
-		newLogger.Error(nil, "%#v\n", maskAny(err))
-		os.Exit(1)
-	}
-	req, err = newController.ExtendWithRandomSliceIDs(req)
+	req, err := createSubmitRequest(fs, group, scale)
 	if err != nil {
 		newLogger.Error(nil, "%#v", maskAny(err))
 		os.Exit(1)
@@ -67,4 +59,26 @@ func submitRun(cmd *cobra.Command, args []string) {
 		TaskID:     taskObject.ID,
 		Closer:     nil,
 	})
+}
+
+func createSubmitRequest(fs filesystemspec.FileSystem, group string, scale int) (controller.Request, error) {
+	newRequestConfig := controller.DefaultRequestConfig()
+	newRequestConfig.Group = group
+
+	req := controller.NewRequest(newRequestConfig)
+	req, err := extendRequestWithContent(fs, req)
+	if err != nil {
+		return controller.Request{}, err
+	}
+
+	if strings.Contains(req.Units[0].Name, "@") {
+		req.DesiredSlices = scale
+	} else {
+		if scale != 1 {
+			return controller.Request{}, errgo.Newf("invalid scale: must be 1 for unscalable groups")
+		}
+		req.DesiredSlices = 1
+	}
+	req.SliceIDs = nil
+	return req, nil
 }

--- a/cli/submit_test.go
+++ b/cli/submit_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/giantswarm/inago/file-system/fake"
+	"github.com/giantswarm/inago/file-system/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func givenFileSystemWithSingleUnitGroup(name string) filesystemspec.FileSystem {
+	fs := filesystemfake.NewFileSystem()
+	fs.WriteFile(name+"/"+name+"-1.service", []byte(`some content`), os.FileMode(0644))
+	return fs
+}
+func givenFileSystemWithSliceableUnitGroup(name string) filesystemspec.FileSystem {
+	fs := filesystemfake.NewFileSystem()
+	fs.WriteFile(name+"/"+name+"-1@.service", []byte(`some content`), os.FileMode(0644))
+	return fs
+}
+
+func TestCreateSubmitRequest_NoSlices(t *testing.T) {
+	RegisterTestingT(t)
+
+	groupname := "foo"
+	fs := givenFileSystemWithSingleUnitGroup(groupname)
+	scale := 1
+
+	req, err := createSubmitRequest(fs, groupname, scale)
+	Expect(err).To(BeNil())
+	Expect(req.Group).To(Equal(groupname))
+	Expect(req.DesiredSlices).To(Equal(1))
+	Expect(req.SliceIDs).To(BeNil())
+}
+
+func TestCreateSubmitRequest_NoSlices_InvalidScale(t *testing.T) {
+	RegisterTestingT(t)
+
+	groupname := "foo"
+	fs := givenFileSystemWithSingleUnitGroup(groupname)
+	scale := 3
+
+	_, err := createSubmitRequest(fs, groupname, scale)
+	Expect(err).To(Not(BeNil()))
+
+}
+
+func TestCreateSubmitRequest_WithSlices(t *testing.T) {
+	RegisterTestingT(t)
+
+	groupname := "foo"
+	fs := givenFileSystemWithSliceableUnitGroup(groupname)
+
+	scale := 3
+
+	req, err := createSubmitRequest(fs, groupname, scale)
+	Expect(err).To(BeNil())
+	Expect(req.Group).To(Equal(groupname))
+	Expect(req.DesiredSlices).To(Equal(3))
+	Expect(len(req.SliceIDs)).To(Equal(0))
+}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -404,6 +405,12 @@ func TestController_Submit(t *testing.T) {
 
 	// Mocks
 	controller, fleetMock := givenController()
+
+	fleetMock.On("Submit", mock.MatchedBy(func(unitname string) bool {
+		// "test-main@xxx.service", "content"
+		return strings.HasPrefix(unitname, "test-main@") &&
+			strings.HasSuffix(unitname, ".service")
+	}), "content").Return(nil).Once()
 	fleetMock.On("GetStatusWithMatcher", mock.AnythingOfType("func(string) bool")).Return(
 		[]fleet.UnitStatus{
 			{
@@ -412,17 +419,16 @@ func TestController_Submit(t *testing.T) {
 		},
 		nil,
 	)
-	fleetMock.On("Submit", "test-main@1.service", "content").Return(nil).Once()
 
 	// Execute test
 	req := Request{
 		RequestConfig: RequestConfig{
-			Group:    "test",
-			SliceIDs: []string{"1"},
+			Group:         "test",
+			DesiredSlices: 1,
 		},
 		Units: []Unit{
 			{
-				Name:    "test-main@1.service",
+				Name:    "test-main@.service",
 				Content: "content",
 			},
 		},

--- a/controller/error.go
+++ b/controller/error.go
@@ -143,3 +143,10 @@ var groupsSameNameError = errgo.New("group named with same name as another group
 func IsGroupsSameName(err error) bool {
 	return errgo.Cause(err) == groupsSameNameError
 }
+
+var invalidSubmitRequestSlicesGivenError = errgo.New("invalid submit request: slice ids given")
+
+// InvalidSubmitRequestSlicesGiven returns true if the given error cause is invalidSubmitRequestSlicesGivenError.
+func InvalidSubmitRequestSlicesGiven(err error) bool {
+	return errgo.Cause(err) == invalidSubmitRequestSlicesGivenError
+}

--- a/controller/request.go
+++ b/controller/request.go
@@ -23,6 +23,10 @@ type RequestConfig struct {
 	// SliceIDs contains the IDs to create. IDs can be "1", "first", "whatever",
 	// "5", etc..
 	SliceIDs []string
+
+	// DesiredSlices defines the number of random sliceIDs that should be generated
+	// when submitting new groups.
+	DesiredSlices int
 }
 
 // Request represents a controller request. This is used to process some action
@@ -132,12 +136,7 @@ func (c controller) ExtendWithRandomSliceIDs(req Request) (Request, error) {
 
 	// Find enough sufficient IDs.
 	var newIDs []string
-	for _, sliceID := range req.SliceIDs {
-		if sliceID == "" {
-			// This unit has no explicit slice ID. Skip it.
-			continue
-		}
-
+	for i := 0; i < req.DesiredSlices; i++ {
 		for {
 			newID := NewID()
 

--- a/controller/validator.go
+++ b/controller/validator.go
@@ -72,6 +72,16 @@ func StringsHaveOrNot(s []string, c string) bool {
 	return !(numStringsWithOccurence > 0 && numStringsWithOccurence < len(s))
 }
 
+// ValidateSubmitRequest validates that the given request contains no SliceIDs.
+// Otherwise it is identical to ValidateRequest().
+func ValidateSubmitRequest(request Request) (bool, error) {
+	if len(request.SliceIDs) != 0 {
+		return false, maskAny(invalidSubmitRequestSlicesGivenError)
+	}
+
+	return ValidateRequest(request)
+}
+
 // ValidateRequest takes a Request, and returns whether it is valid or not.
 // If the request is not valid, the error provides more details.
 func ValidateRequest(request Request) (bool, error) {
@@ -86,7 +96,6 @@ func ValidateRequest(request Request) (bool, error) {
 	}
 
 	unitNames := []string{}
-
 	for _, unit := range request.Units {
 		unitNames = append(unitNames, unit.Name)
 	}

--- a/example/simple-global-unit/simple-global-unit-replicator.service
+++ b/example/simple-global-unit/simple-global-unit-replicator.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=A simple global unit for fleet and Inago
+
+[Service]
+ExecStart=/bin/bash -c "while true; do echo hi; sleep 10; done"
+
+[X-Fleet]
+Global=true


### PR DESCRIPTION
Fixes #89 

We moved the logic to replace the slice IDs with random IDs into the controller to make it easier to test Request creation in the cli.
We also added logic to not set the scale above 1, when the group cannot be sliced/scaled.

```
$ ../inagoctl --fleet-endpoint="http://172.17.8.101:49153" submit simple-global-unit 2
2016-03-14 18:12:07 | ERROR    | [{/usr/code/.gobuild/src/github.com/giantswarm/inago/cli/submit.go:45: 
} {/usr/code/.gobuild/src/github.com/giantswarm/inago/cli/submit.go:78: invalid scale: must be 1 for 
unscalable groups}]
```

<!---
@huboard:{"custom_state":"archived"}
-->
