### PR TITLE
Make usage and flag help text a little more consistent

### DIFF
--- a/cli/destroy.go
+++ b/cli/destroy.go
@@ -10,9 +10,9 @@ import (
 
 var (
 	destroyCmd = &cobra.Command{
-		Use:   "destroy [group [group..]]",
-		Short: "Destroys the specified group or slices",
-		Long:  "Destroys a group or the specified slices",
+		Use:   "destroy <group|slice...>",
+		Short: "Destroy a group",
+		Long:  "Destroy the specified group, or slices",
 		Run:   destroyRun,
 	}
 )

--- a/cli/inagoctl.go
+++ b/cli/inagoctl.go
@@ -31,8 +31,8 @@ var (
 	// MainCmd contains the cobra.Command to execute inagoctl.
 	MainCmd = &cobra.Command{
 		Use:   "inagoctl",
-		Short: "orchestrate groups of unit files on Fleet clusters",
-		Long:  "orchestrate groups of unit files on Fleet clusters",
+		Short: "Inago orchestrates groups of units on Fleet clusters",
+		Long:  "Inago orchestrates groups of units on Fleet clusters",
 		Run:   mainRun,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// This callback is executed after flags are parsed and before any
@@ -74,8 +74,8 @@ var (
 
 func init() {
 	MainCmd.PersistentFlags().StringVar(&globalFlags.FleetEndpoint, "fleet-endpoint", "unix:///var/run/fleet.sock", "endpoint used to connect to fleet")
-	MainCmd.PersistentFlags().BoolVar(&globalFlags.NoBlock, "no-block", false, "block on synchronous actions or not")
-	MainCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "v", false, "verbose output or not")
+	MainCmd.PersistentFlags().BoolVar(&globalFlags.NoBlock, "no-block", false, "block on synchronous actions")
+	MainCmd.PersistentFlags().BoolVarP(&globalFlags.Verbose, "verbose", "v", false, "verbose output")
 
 	MainCmd.AddCommand(submitCmd)
 	MainCmd.AddCommand(statusCmd)

--- a/cli/start.go
+++ b/cli/start.go
@@ -10,9 +10,9 @@ import (
 
 var (
 	startCmd = &cobra.Command{
-		Use:   "start [group [group..]]",
-		Short: "Starts the specified group or slices",
-		Long:  "Starts a group or the specified slices",
+		Use:   "start <group|slice...>",
+		Short: "Start a group",
+		Long:  "Start the specified group, or slices",
 		Run:   startRun,
 	}
 )

--- a/cli/status.go
+++ b/cli/status.go
@@ -12,9 +12,9 @@ import (
 
 var (
 	statusCmd = &cobra.Command{
-		Use:   "status [group-slice] ...",
-		Short: "status of a group",
-		Long:  "status of a group",
+		Use:   "status <group>",
+		Short: "Get group status",
+		Long:  "Print the status of a group",
 		Run:   statusRun,
 	}
 )

--- a/cli/stop.go
+++ b/cli/stop.go
@@ -10,9 +10,9 @@ import (
 
 var (
 	stopCmd = &cobra.Command{
-		Use:   "stop [group [group..]]",
-		Short: "Stops the specified group or slices",
-		Long:  "Stops a group or the specified slices",
+		Use:   "stop <group|slice...>",
+		Short: "Stop a group",
+		Long:  "Stop the specified group, or slices",
 		Run:   stopRun,
 	}
 )

--- a/cli/submit.go
+++ b/cli/submit.go
@@ -13,8 +13,8 @@ import (
 var (
 	submitCmd = &cobra.Command{
 		Use:   "submit <group> [scale]",
-		Short: "submit a group",
-		Long:  "submit a group",
+		Short: "Submit a group",
+		Long:  "Submit a group to the cluster, with an optional scale",
 		Run:   submitRun,
 	}
 )

--- a/cli/update.go
+++ b/cli/update.go
@@ -17,9 +17,9 @@ var (
 	}
 
 	updateCmd = &cobra.Command{
-		Use:   "update [group]",
-		Short: "update a group",
-		Long:  "update a group",
+		Use:   "update <group>",
+		Short: "Update a group",
+		Long:  "Update a group to the latest version on the local filesystem",
 		Run:   updateRun,
 	}
 )

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -13,9 +13,9 @@ import (
 
 var (
 	validateCmd = &cobra.Command{
-		Use:   "validate",
-		Short: "validate groups",
-		Long:  "validate groups",
+		Use:   "validate [directory]",
+		Short: "Validate groups",
+		Long:  "Validate group directories on the local filesystem",
 		Run:   validateRun,
 	}
 )


### PR DESCRIPTION
Fixes https://github.com/giantswarm/inago/issues/75
- Using upper case for both short and long command text
- Using lower case for flag text
- `<foo>` for required arguments
- `[foo]` for optional arguments
- `|` for or style
- `...` for "multiple" arguments

<!---
@huboard:{"custom_state":"archived"}
-->
