### PR TITLE
fleet: For global units, return a nicer global status

### DIFF
--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -4,6 +4,7 @@
 package fleet
 
 import (
+	"strings"
 	"net"
 	"net/http"
 	"net/url"
@@ -363,7 +364,9 @@ func mapFleetStateToUnitStatusList(foundFleetUnits []*schema.Unit, foundFleetUni
 
 func isFleetGlobalUnit(options []*schema.UnitOption) bool {
 	for _, option := range options {
-		if option.Section == "X-Fleet" && option.Name == "Global" && option.Value == "true" {
+		if strings.EqualFold(option.Section, "X-Fleet") &&
+		 strings.EqualFold(option.Name, "Global") &&
+		 strings.EqualFold(option.Value, "true") {
 			return true
 		}
 	}

--- a/fleet/fleet.go
+++ b/fleet/fleet.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
+
 	"github.com/coreos/fleet/client"
 	"github.com/coreos/fleet/machine"
 	"github.com/coreos/fleet/schema"
@@ -329,10 +330,18 @@ func mapFleetStateToUnitStatusList(foundFleetUnits []*schema.Unit, foundFleetUni
 			Name:    ffu.Name,
 			SliceID: ID,
 		}
+
+		// FLEET-WEIRDNESS: In case of global units, the CurrentState seems to be always "inactive"
+		// To make the output a bit nicer, we overwrite it with DesiredState
+		if isFleetGlobalUnit(ffu.Options) {
+			ourUnitStatus.Current = ourUnitStatus.Desired
+		}
+
 		for _, ffus := range foundFleetUnitStates {
 			if ffu.Name != ffus.Name {
 				continue
 			}
+
 			IP, err := ipFromUnitState(ffus, machines)
 			if err != nil {
 				return []UnitStatus{}, maskAny(err)
@@ -350,4 +359,13 @@ func mapFleetStateToUnitStatusList(foundFleetUnits []*schema.Unit, foundFleetUni
 	}
 
 	return ourStatusList, nil
+}
+
+func isFleetGlobalUnit(options []*schema.UnitOption) bool {
+	for _, option := range options {
+		if option.Section == "X-Fleet" && option.Name == "Global" && option.Value == "true" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This adds special treatment for global units.  Fleet returns `"inactive"` for the CurrentStatus, even if all units on all machines are running just fine. This PR changes the returned FleetCurrentStatus to always be FleetDesiredStatus, to make this a bit more logical.

<!---
@huboard:{"custom_state":"archived"}
-->
