### PR TITLE
IntTests: Golden path for instance groups

### DIFF
--- a/int-tests/050-instance-goldenpath.t
+++ b/int-tests/050-instance-goldenpath.t
@@ -1,0 +1,22 @@
+This cram test performs the basic operations on an instance group, meaning no slices.
+
+Setup unit files
+
+  $ GROUP=050-simple-group
+  $ mkdir $GROUP
+  $ echo "[Unit]\nDescription=Unit 1\n[Service]\nExecStart=/bin/bash -c 'while true; do echo Hello %n; sleep 10; done'\n" > $GROUP/$GROUP-1-unit.service
+  $ echo "[Unit]\nDescription=Unit 1\n[Service]\nExecStart=/bin/bash -c 'while true; do echo Hello %n; sleep 10; done'\n[X-Fleet]\nMachineOf=$GROUP-1-unit.service\n" > $GROUP/$GROUP-2-unit.service
+
+Submit units
+
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} submit $GROUP >010.out 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >021.out
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP >025.out
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} start $GROUP >030.out 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >041.out
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP > 045.out 
+  $ sleep 10
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} stop $GROUP >050.out 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >061.out
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP >065.out
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} destroy $GROUP >070.out 2>&1


### PR DESCRIPTION
This PR adds an int test to run the submit/Start/stop/destroy golden path for a simple instance group (no slices) with two units. It seem to basically work, although if I do not redirect the output, it does not yet look like what I expect. I guess we have a bug in inago here. But I will focus on that in a separate PR. 

<!---
@huboard:{"custom_state":"archived"}
-->
