### PR TITLE
Fixes submitting of unit names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,16 @@ int-test: $(BIN) $(INT_TESTS)
 	@echo Starting CoreOS integration test machine
 	cd $(VAGRANT_PATH) && vagrant up
 	sleep 10
-	-docker run \
+
+	-FLEET_ENDPOINT=$(FLEET_ENDPOINT) make internal-int-test
+
+	@echo Destroying the integration test machine
+	cd $(VAGRANT_PATH) && vagrant destroy -f
+	@echo Removing test machine user-data
+	rm $(VAGRANT_PATH)/user-data
+
+internal-int-test: $(BIN) $(INT_TESTS)
+	docker run \
 		--rm \
 		-ti \
 		-e FLEET_ENDPOINT=$(FLEET_ENDPOINT) \
@@ -109,7 +118,3 @@ int-test: $(BIN) $(INT_TESTS)
 		-v $(INT_TESTS_PATH):$(INT_TESTS_PATH) \
 		zeisss/cram-docker \
 		-v $(INT_TESTS_PATH)
-	@echo Destroying the integration test machine
-	cd $(VAGRANT_PATH) && vagrant destroy -f
-	@echo Removing test machine user-data
-	rm $(VAGRANT_PATH)/user-data

--- a/cli/request.go
+++ b/cli/request.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"path/filepath"
 
+	"github.com/juju/errgo"
+
 	"github.com/giantswarm/inago/controller"
 	"github.com/giantswarm/inago/file-system/spec"
 )
@@ -41,6 +43,10 @@ func extendRequestWithContent(fs filesystemspec.FileSystem, req controller.Reque
 	}
 	for name, content := range unitFiles {
 		req.Units = append(req.Units, controller.Unit{Name: name, Content: content})
+	}
+
+	if len(req.Units) == 0 {
+		return controller.Request{}, errgo.Newf("No unit files found for group '%s'", req.Group)
 	}
 
 	return req, nil

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -218,7 +218,7 @@ func (c controller) Submit(ctx context.Context, req Request) (*task.Task, error)
 
 		c.Config.Logger.Debug(ctx, "action: waiting for status of submitted units")
 		closer := make(chan struct{})
-		err = c.WaitForStatus(ctx, req, StatusStopped, closer)
+		err = c.WaitForStatus(ctx, extended, StatusStopped, closer)
 		if err != nil {
 			return maskAny(err)
 		}

--- a/controller/request.go
+++ b/controller/request.go
@@ -54,7 +54,7 @@ func NewRequest(config RequestConfig) Request {
 var unitExp = regexp.MustCompile("@.")
 
 // IsSlicable checks whether all units of the request are sliceable (contain an @)
-func (r Request) IsSlicable() bool {
+func (r Request) IsSliceable() bool {
 	for _, unit := range r.Units {
 		if !unitExp.MatchString(unit.Name) {
 			return false
@@ -138,7 +138,7 @@ func contains(l []string, e string) bool {
 }
 
 func (c controller) ExtendWithRandomSliceIDs(req Request) (Request, error) {
-	if !req.IsSlicable() {
+	if !req.IsSliceable() {
 		return req, nil
 	}
 

--- a/controller/request.go
+++ b/controller/request.go
@@ -53,6 +53,16 @@ func NewRequest(config RequestConfig) Request {
 
 var unitExp = regexp.MustCompile("@.")
 
+// IsSlicable checks whether all units of the request are sliceable (contain an @)
+func (r Request) IsSlicable() bool {
+	for _, unit := range r.Units {
+		if !unitExp.MatchString(unit.Name) {
+			return false
+		}
+	}
+	return true
+}
+
 // ExtendSlices extends unit files with respect to the given slice IDs. Having
 // slice IDs "1" and "2" and having unit files "foo@.service" and
 // "bar@.service" results in the following extended unit files.
@@ -128,6 +138,10 @@ func contains(l []string, e string) bool {
 }
 
 func (c controller) ExtendWithRandomSliceIDs(req Request) (Request, error) {
+	if !req.IsSlicable() {
+		return req, nil
+	}
+
 	// Lookup existing slice IDs.
 	usl, err := c.groupStatusWithValidate(req)
 	if IsUnitNotFound(err) {

--- a/int-tests/002-update.t
+++ b/int-tests/002-update.t
@@ -1,7 +1,7 @@
 Create a group to play around with.
   $ mkdir update-group
-  $ echo "[Unit]\nDescription=Inago Update Test Unit\n\n[Service]\nExecStart=/bin/bash -c \"while true; do echo Hi; sleep 10; done\"" > update-group/update-group-foo@.service
-  $ echo "[Unit]\nDescription=Inago Update Test Unit\n\n[Service]\nExecStart=/bin/bash -c \"while true; do echo Hi; sleep 10; done\"" > update-group/update-group-bar@.service
+  $ printf "[Unit]\nDescription=Inago Update Test Unit\n\n[Service]\nExecStart=/bin/bash -c \"while true; do echo Hi; sleep 10; done\"\n" > update-group/update-group-foo@.service
+  $ printf "[Unit]\nDescription=Inago Update Test Unit\n\n[Service]\nExecStart=/bin/bash -c \"while true; do echo Hi; sleep 10; done\"\n" > update-group/update-group-bar@.service
 
 Validate the test group.
   $ inagoctl validate update-group

--- a/int-tests/003-err-submit-twice.t
+++ b/int-tests/003-err-submit-twice.t
@@ -1,0 +1,15 @@
+We had a bug where submit would block forever, because it would check on the wrong unit files.
+
+  $ GROUP="test-group-003"
+  $ mkdir $GROUP 
+  $ printf "[Unit]\nDescription=Inago Test Unit $GROUP\n\n[Service]\nExecStart=/bin/bash -c \"while true; do echo Hi $GROUP; sleep 10; done\"\n" > $GROUP/$GROUP-unit.service
+
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} submit $GROUP >/dev/null 2>&1 
+  $ sleep 5
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} start $GROUP >/dev/null 2>&1
+  $ sleep 5
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} submit $GROUP >/dev/null 2>&1
+
+Cleanup
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP >/dev/null 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} destroy $GROUP >/dev/null 2>&1

--- a/int-tests/050-instance-goldenpath.t
+++ b/int-tests/050-instance-goldenpath.t
@@ -10,13 +10,13 @@ Setup unit files
 Submit units
 
   $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} submit $GROUP >010.out 2>&1
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >021.out
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP >025.out
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >021.out 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP >025.out 2>&1
   $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} start $GROUP >030.out 2>&1
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >041.out
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP > 045.out 
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >041.out 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP > 045.out  2>&1
   $ sleep 10
   $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} stop $GROUP >050.out 2>&1
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >061.out
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP >065.out
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP -v >061.out 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} status $GROUP >065.out 2>&1
   $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} destroy $GROUP >070.out 2>&1


### PR DESCRIPTION
This fixes a bunch of things. Sorry for making it one PR.
# panic for empty folders

```
$ mkdir foo/
$ ../inagoctl --fleet-endpoint=${FLEET_ENDPOINT} submit -v foo
2016-03-16 18:39:51.846 | DEBUG    | context.Background: cli: starting submit
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/giantswarm/inago/cli.createSubmitRequest(0x8820836ae0, 0x75a418, 0x7fff5fbffac9, 0x3, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /usr/code/.gobuild/src/github.com/giantswarm/inago/cli/submit.go:76 +0x49b
github.com/giantswarm/inago/cli.submitRun(0x739e00, 0x8207f5b90, 0x1, 0x3)
    /usr/code/.gobuild/src/github.com/giantswarm/inago/cli/submit.go:45 +0x10f
github.com/spf13/cobra.(*Command).execute(0x739e00, 0x8207f5a10, 0x3, 0x3, 0x0, 0x0)
    /usr/code/.gobuild/src/github.com/spf13/cobra/command.go:569 +0x85a
github.com/spf13/cobra.(*Command).ExecuteC(0x739600, 0x739e00, 0x0, 0x0)
    /usr/code/.gobuild/src/github.com/spf13/cobra/command.go:656 +0x55c
github.com/spf13/cobra.(*Command).Execute(0x739600, 0x0, 0x0)
    /usr/code/.gobuild/src/github.com/spf13/cobra/command.go:615 +0x2d
main.main()
    /usr/code/main.go:11 +0x27
```
# you cannot do a second submit, if the first one is already started

fixes #124 + adds a test
# Adds make internal-int-test to specify your own fleet VM

well, same `make int-test`, it just doesn't boot the VM.

<!---
@huboard:{"custom_state":"archived"}
-->
