### PR TITLE
Check number of slice ids, to determine slice or slices

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -83,6 +83,11 @@ type blockWithFeedbackCtx struct {
 }
 
 func maybeBlockWithFeedback(ctx context.Context, bctx blockWithFeedbackCtx) {
+	sliceNoun := "slices"
+	if len(bctx.Request.SliceIDs) == 1 {
+		sliceNoun = "slice"
+	}
+
 	if !bctx.NoBlock {
 		taskObject, err := newController.WaitForTask(ctx, bctx.TaskID, bctx.Closer)
 		if err != nil {
@@ -96,7 +101,16 @@ func maybeBlockWithFeedback(ctx context.Context, bctx blockWithFeedbackCtx) {
 			} else if len(bctx.Request.SliceIDs) == 0 {
 				newLogger.Error(ctx, "Failed to %s all slices of group '%s'. (%s)", bctx.Descriptor, bctx.Request.Group, taskObject.Error)
 			} else {
-				newLogger.Error(ctx, "Failed to %s %d slices for group '%s': %v. (%s)", bctx.Descriptor, len(bctx.Request.SliceIDs), bctx.Request.Group, bctx.Request.SliceIDs, taskObject.Error)
+				newLogger.Error(
+					ctx,
+					"Failed to %s %d %v for group '%s': %v. (%s)",
+					bctx.Descriptor,
+					len(bctx.Request.SliceIDs),
+					sliceNoun,
+					bctx.Request.Group,
+					bctx.Request.SliceIDs,
+					taskObject.Error,
+				)
 			}
 			os.Exit(1)
 		}
@@ -107,6 +121,14 @@ func maybeBlockWithFeedback(ctx context.Context, bctx blockWithFeedbackCtx) {
 	} else if len(bctx.Request.SliceIDs) == 0 {
 		newLogger.Info(ctx, "Succeeded to %s all slices of group '%s'.", bctx.Descriptor, bctx.Request.Group)
 	} else {
-		newLogger.Info(ctx, "Succeeded to %s %d slices for group '%s': %v.", bctx.Descriptor, len(bctx.Request.SliceIDs), bctx.Request.Group, bctx.Request.SliceIDs)
+		newLogger.Info(
+			ctx,
+			"Succeeded to %s %d %v for group '%s': %v.",
+			bctx.Descriptor,
+			len(bctx.Request.SliceIDs),
+			sliceNoun,
+			bctx.Request.Group,
+			bctx.Request.SliceIDs,
+		)
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/giantswarm/inago/issues/125

```
core@core-01 ~ $ ./inagoctl submit mygroup 1
2016-03-22 10:43:37.579 | INFO     | context.Background: Succeeded to submit group 'mygroup'.
core@core-01 ~ $ ./inagoctl destroy mygroup
2016-03-22 10:43:45.348 | INFO     | context.Background: Succeeded to destroy 1 slice for group 'mygroup': [870].
core@core-01 ~ $ ./inagoctl submit mygroup 2
2016-03-22 10:43:54.178 | INFO     | context.Background: Succeeded to submit group 'mygroup'.
core@core-01 ~ $ ./inagoctl destroy mygroup
2016-03-22 10:44:01.407 | INFO     | context.Background: Succeeded to destroy 2 slices for group 'mygroup': [656 6b5].
```

this makes me far too happy

<!---
@huboard:{"custom_state":"archived"}
-->
