### PR TITLE
Remove tty allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ $(BIN): $(SOURCE) VERSION .gobuild
 	@echo Building inside Docker container for $(GOOS)/$(GOARCH)
 	docker run \
 	    --rm \
-	    -ti \
 	    -v $(shell pwd):/usr/code \
 	    -e GOPATH=/usr/code/.gobuild \
 	    -e GOOS=$(GOOS) \
@@ -70,7 +69,6 @@ test: $(SOURCE) VERSION .gobuild
 	@echo Testing inside Docker container for $(GOOS)/$(GOARCH)
 	docker run \
 	    --rm \
-	    -ti \
 	    -v $(shell pwd):/usr/code \
 	    -e GOPATH=/usr/code/.gobuild \
 	    -e GOOS=$(GOOS) \
@@ -115,7 +113,6 @@ int-test: $(BIN) $(INT_TESTS)
 internal-int-test: $(BIN) $(INT_TESTS)
 	docker run \
 		--rm \
-		-ti \
 		-e FLEET_ENDPOINT=$(FLEET_ENDPOINT) \
 		-v $(CURDIR)/$(BIN):/usr/local/bin/$(BIN) \
 		-v $(INT_TESTS_PATH):$(INT_TESTS_PATH) \


### PR DESCRIPTION
When releasing with `builder`, I get:

```
    Building inside Docker container for darwin/
    docker run \
            --rm \
            -ti \
            -v /Users/joseph/Repos/inago:/usr/code \
            -e GOPATH=/usr/code/.gobuild \
            -e GOOS=darwin \
            -e GOARCH= \
            -w /usr/code \
            golang:1.6 \
            go build -a -ldflags "-X github.com/giantswarm/inago/cli.projectVersion=0.1.0 -X github.com/giantswarm/inago/cli.projectBuild=51998d2" -o inagoctl


    Output of stderr was:

        cannot enable tty mode on non tty input
    make: *** [inagoctl] Error 1
```

So, I'm removing `-ti` from our docker commands.

<!---
@huboard:{"custom_state":"archived"}
-->
