### PR TITLE
Support destroying slices

### DIFF
--- a/cli/destroy.go
+++ b/cli/destroy.go
@@ -27,7 +27,7 @@ func destroyRun(cmd *cobra.Command, args []string) {
 
 	var err error
 	newRequestConfig := controller.DefaultRequestConfig()
-	newRequestConfig.Group, newRequestConfig.SliceIDs, err = parseGroupCLIargs(args)
+	newRequestConfig.Group, newRequestConfig.SliceIDs, err = parseGroupCLIArgs(args)
 	if err != nil {
 		newLogger.Error(newCtx, "%#v", maskAny(err))
 		os.Exit(1)

--- a/cli/error.go
+++ b/cli/error.go
@@ -14,6 +14,12 @@ var (
 
 var invalidArgumentsError = errgo.Newf("invalid arguments")
 
+// IsInvalidArgumentsError checks whether the given command line
+// arguments are valid
+func IsInvalidArgumentsError(err error) bool {
+	return errgo.Cause(err) == invalidArgumentsError
+}
+
 // FormatValidationError returns the CausingErrors formatted:
 // Validation Error found:
 //		* unit slice not found

--- a/cli/request.go
+++ b/cli/request.go
@@ -53,7 +53,10 @@ func extendRequestWithContent(fs filesystemspec.FileSystem, req controller.Reque
 	return req, nil
 }
 
-func parseGroupCLIargs(args []string) (string, []string, error) {
+// parseGroupCLIArgs parses the given group arguments into a group and the
+// given sliceIDs.
+// "mygroup@123", "mygroup@456" => "mygroup", ["123", "456"]
+func parseGroupCLIArgs(args []string) (string, []string, error) {
 	group := strings.Split(args[0], "@")[0]
 	sliceIDs := []string{}
 

--- a/cli/request.go
+++ b/cli/request.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/juju/errgo"
 
@@ -50,4 +51,24 @@ func extendRequestWithContent(fs filesystemspec.FileSystem, req controller.Reque
 	}
 
 	return req, nil
+}
+
+func parseGroupCLIargs(args []string) (string, []string, error) {
+	group := strings.Split(args[0], "@")[0]
+	sliceIDs := []string{}
+
+	for _, arg := range args {
+		split := strings.Split(arg, "@")
+		// validate that groups are not mixed
+		if split[0] != group {
+			// TODO better error message
+			return "", nil, maskAny(invalidArgumentsError)
+		}
+		// only append slice ID if one was provided
+		if len(split) > 1 {
+			sliceIDs = append(sliceIDs, split[1])
+		}
+	}
+
+	return group, sliceIDs, nil
 }

--- a/cli/request.go
+++ b/cli/request.go
@@ -61,7 +61,6 @@ func parseGroupCLIargs(args []string) (string, []string, error) {
 		split := strings.Split(arg, "@")
 		// validate that groups are not mixed
 		if split[0] != group {
-			// TODO better error message
 			return "", nil, maskAny(invalidArgumentsError)
 		}
 		// only append slice ID if one was provided

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -153,15 +153,14 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 	}
 }
 
-func Test_Request_ParseGroupCLIargs(t *testing.T) {
+func Test_Request_ParseGroupCLIargs_Success(t *testing.T) {
 	type Expected struct {
 		Group    string
 		SliceIDs []string
 	}
 	testCases := []struct {
-		Input      []string
-		Expected   Expected
-		CheckError func(error) bool
+		Input    []string
+		Expected Expected
 	}{
 		// Tests that no sliceIDs are returned when non where provided
 		{
@@ -170,7 +169,6 @@ func Test_Request_ParseGroupCLIargs(t *testing.T) {
 				Group:    "mygroup",
 				SliceIDs: []string{},
 			},
-			CheckError: nil,
 		},
 		// Tests that group and slice are split correctly
 		{
@@ -179,7 +177,6 @@ func Test_Request_ParseGroupCLIargs(t *testing.T) {
 				Group:    "mygroup",
 				SliceIDs: []string{"1"},
 			},
-			CheckError: nil,
 		},
 		// Tests that multiple group sliceIDs are split correctly
 		{
@@ -188,34 +185,13 @@ func Test_Request_ParseGroupCLIargs(t *testing.T) {
 				Group:    "mygroup",
 				SliceIDs: []string{"1", "2"},
 			},
-			CheckError: nil,
-		},
-		// Tests that mixed groups return an invalidArgumentsError
-		{
-			Input:      []string{"mygroup@1", "othergroup"},
-			Expected:   Expected{},
-			CheckError: IsInvalidArgumentsError,
-		},
-		// Tests that mixed groups with sliceIDs return an invalidArgumentsError
-		{
-			Input:      []string{"mygroup@1", "othergroup@2"},
-			Expected:   Expected{},
-			CheckError: IsInvalidArgumentsError,
-		},
-		// Tests that using two different groups fails
-		{
-			Input:      []string{"mygroup", "othergroup"},
-			Expected:   Expected{},
-			CheckError: IsInvalidArgumentsError,
 		},
 	}
 
 	for _, test := range testCases {
 		group, sliceIDs, err := parseGroupCLIArgs(test.Input)
 		if err != nil {
-			if !test.CheckError(err) {
-				t.Fatalf("got unexpected Error '%v'", err)
-			}
+			t.Fatalf("got unexpected error: %v", err)
 		}
 
 		if group != test.Expected.Group {
@@ -223,6 +199,30 @@ func Test_Request_ParseGroupCLIargs(t *testing.T) {
 		}
 		if !reflect.DeepEqual(sliceIDs, test.Expected.SliceIDs) {
 			t.Fatalf("got sliceIDs %v, expected sliceIDs to be %v.", sliceIDs, test.Expected.SliceIDs)
+		}
+	}
+}
+
+func Test_Request_ParseGroupCLIargs_Error(t *testing.T) {
+	testCases := []struct {
+		Input      []string
+		CheckError func(error) bool
+	}{ // Tests that mixed groups with sliceIDs return an invalidArgumentsError
+		{
+			Input:      []string{"mygroup@1", "othergroup@2"},
+			CheckError: IsInvalidArgumentsError,
+		},
+		// Tests that using two different groups fails
+		{
+			Input:      []string{"mygroup", "othergroup"},
+			CheckError: IsInvalidArgumentsError,
+		},
+	}
+
+	for _, test := range testCases {
+		_, _, err := parseGroupCLIArgs(test.Input)
+		if !test.CheckError(err) {
+			t.Fatalf("got unexpected Error '%v'", err)
 		}
 	}
 }

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -159,18 +159,18 @@ func Test_Request_ParseGroupCLIargs(t *testing.T) {
 		SliceIDs []string
 	}
 	testCases := []struct {
-		Input    []string
-		Expected Expected
-		Errorf   func(error) bool
+		Input      []string
+		Expected   Expected
+		CheckError func(error) bool
 	}{
-		// Tests that on sliceIDs are returned when non where provided
+		// Tests that no sliceIDs are returned when non where provided
 		{
 			Input: []string{"mygroup"},
 			Expected: Expected{
 				Group:    "mygroup",
 				SliceIDs: []string{},
 			},
-			Errorf: nil,
+			CheckError: nil,
 		},
 		// Tests that group and slice are split correctly
 		{
@@ -179,7 +179,7 @@ func Test_Request_ParseGroupCLIargs(t *testing.T) {
 				Group:    "mygroup",
 				SliceIDs: []string{"1"},
 			},
-			Errorf: nil,
+			CheckError: nil,
 		},
 		// Tests that multiple group sliceIDs are split correctly
 		{
@@ -188,26 +188,32 @@ func Test_Request_ParseGroupCLIargs(t *testing.T) {
 				Group:    "mygroup",
 				SliceIDs: []string{"1", "2"},
 			},
-			Errorf: nil,
+			CheckError: nil,
 		},
 		// Tests that mixed groups return an invalidArgumentsError
 		{
-			Input:    []string{"mygroup@1", "othergroup"},
-			Expected: Expected{},
-			Errorf:   IsInvalidArgumentsError,
+			Input:      []string{"mygroup@1", "othergroup"},
+			Expected:   Expected{},
+			CheckError: IsInvalidArgumentsError,
+		},
+		// Tests that mixed groups with sliceIDs return an invalidArgumentsError
+		{
+			Input:      []string{"mygroup@1", "othergroup@2"},
+			Expected:   Expected{},
+			CheckError: IsInvalidArgumentsError,
 		},
 		// Tests that using two different groups fails
 		{
-			Input:    []string{"mygroup", "othergroup"},
-			Expected: Expected{},
-			Errorf:   IsInvalidArgumentsError,
+			Input:      []string{"mygroup", "othergroup"},
+			Expected:   Expected{},
+			CheckError: IsInvalidArgumentsError,
 		},
 	}
 
 	for _, test := range testCases {
-		group, sliceIDs, err := parseGroupCLIargs(test.Input)
+		group, sliceIDs, err := parseGroupCLIArgs(test.Input)
 		if err != nil {
-			if !test.Errorf(err) {
+			if !test.CheckError(err) {
 				t.Fatalf("got unexpected Error '%v'", err)
 			}
 		}

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -153,7 +153,7 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 	}
 }
 
-func Test_Request_ParseGroupCLIargs_Success(t *testing.T) {
+func Test_Request_ParseGroupCLIArgs_Success(t *testing.T) {
 	type Expected struct {
 		Group    string
 		SliceIDs []string
@@ -203,7 +203,7 @@ func Test_Request_ParseGroupCLIargs_Success(t *testing.T) {
 	}
 }
 
-func Test_Request_ParseGroupCLIargs_Error(t *testing.T) {
+func Test_Request_ParseGroupCLIArgs_Error(t *testing.T) {
 	testCases := []struct {
 		Input      []string
 		CheckError func(error) bool

--- a/cli/request_test.go
+++ b/cli/request_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/juju/errgo"
@@ -148,6 +149,74 @@ func Test_Request_ExtendWithContent(t *testing.T) {
 			if !found {
 				t.Fatalf("case %d: expected %s to be in output, not found", i+1, outputUnit.Name)
 			}
+		}
+	}
+}
+
+func Test_Request_ParseGroupCLIargs(t *testing.T) {
+	type Expected struct {
+		Group    string
+		SliceIDs []string
+	}
+	testCases := []struct {
+		Input    []string
+		Expected Expected
+		Errorf   func(error) bool
+	}{
+		// Tests that on sliceIDs are returned when non where provided
+		{
+			Input: []string{"mygroup"},
+			Expected: Expected{
+				Group:    "mygroup",
+				SliceIDs: []string{},
+			},
+			Errorf: nil,
+		},
+		// Tests that group and slice are split correctly
+		{
+			Input: []string{"mygroup@1"},
+			Expected: Expected{
+				Group:    "mygroup",
+				SliceIDs: []string{"1"},
+			},
+			Errorf: nil,
+		},
+		// Tests that multiple group sliceIDs are split correctly
+		{
+			Input: []string{"mygroup@1", "mygroup@2"},
+			Expected: Expected{
+				Group:    "mygroup",
+				SliceIDs: []string{"1", "2"},
+			},
+			Errorf: nil,
+		},
+		// Tests that mixed groups return an invalidArgumentsError
+		{
+			Input:    []string{"mygroup@1", "othergroup"},
+			Expected: Expected{},
+			Errorf:   IsInvalidArgumentsError,
+		},
+		// Tests that using two different groups fails
+		{
+			Input:    []string{"mygroup", "othergroup"},
+			Expected: Expected{},
+			Errorf:   IsInvalidArgumentsError,
+		},
+	}
+
+	for _, test := range testCases {
+		group, sliceIDs, err := parseGroupCLIargs(test.Input)
+		if err != nil {
+			if !test.Errorf(err) {
+				t.Fatalf("got unexpected Error '%v'", err)
+			}
+		}
+
+		if group != test.Expected.Group {
+			t.Fatalf("got group %v, expected group to be %v.", group, test.Expected.Group)
+		}
+		if !reflect.DeepEqual(sliceIDs, test.Expected.SliceIDs) {
+			t.Fatalf("got sliceIDs %v, expected sliceIDs to be %v.", sliceIDs, test.Expected.SliceIDs)
 		}
 	}
 }


### PR DESCRIPTION
Add support for supplying sliceIDs when using the destroy command. See #149 for more information.

<!---
@huboard:{"custom_state":"archived"}
-->
