### PR TITLE
fix spelling

### DIFF
--- a/controller/error.go
+++ b/controller/error.go
@@ -8,7 +8,7 @@ import (
 
 // ValidationError capsules validation errors into one error struct.
 // It is returned when the validation fails. CausingErrors contains all
-// errors that occurrenced, while validating the request.
+// errors that occurred, while validating the request.
 type ValidationError struct {
 	CausingErrors []error
 }

--- a/file-system/fake/file.go
+++ b/file-system/fake/file.go
@@ -64,7 +64,7 @@ func newFileInfo(name string, content []byte) os.FileInfo {
 	return newFileInfo
 }
 
-// fileInfo describes a wrapped file isn'tance and is returned by file.Stat
+// fileInfo describes a wrapped file instance and is returned by file.Stat
 type fileInfo struct {
 	File file
 }


### PR DESCRIPTION
The automatic misspell correction did not a good job in all cases. 

RFR @zeisss 

<!---
@huboard:{"custom_state":"archived"}
-->
