### PR TITLE
adds ssh tunneling

### DIFF
--- a/cli/inagoctl.go
+++ b/cli/inagoctl.go
@@ -23,11 +23,11 @@ var (
 		NoBlock       bool
 		Verbose       bool
 
-		Tunnel                string
-		SSHUsername           string
-		SSHTimeout            time.Duration
-		StrictHostKeyChecking bool
-		KnownHostsFile        string
+		Tunnel                   string
+		SSHUsername              string
+		SSHTimeout               time.Duration
+		SSHStrictHostKeyChecking bool
+		SSHKnownHostsFile        string
 	}
 
 	fs             filesystemspec.FileSystem
@@ -67,8 +67,8 @@ var (
 				Tunnel:                globalFlags.Tunnel,
 				Username:              globalFlags.SSHUsername,
 				Timeout:               globalFlags.SSHTimeout,
-				StrictHostKeyChecking: globalFlags.StrictHostKeyChecking,
-				KnownHostsFile:        globalFlags.KnownHostsFile,
+				StrictHostKeyChecking: globalFlags.SSHStrictHostKeyChecking,
+				KnownHostsFile:        globalFlags.SSHKnownHostsFile,
 			}
 
 			newFleet, err = fleet.NewFleet(newFleetConfig)
@@ -100,8 +100,8 @@ func init() {
 	MainCmd.PersistentFlags().StringVar(&globalFlags.Tunnel, "tunnel", "", "use a tunnel to communicate with fleet")
 	MainCmd.PersistentFlags().StringVar(&globalFlags.SSHUsername, "ssh-username", "core", "username to use when connecting to CoreOS machine")
 	MainCmd.PersistentFlags().DurationVar(&globalFlags.SSHTimeout, "ssh-timeout", time.Duration(10*time.Second), "timeout in seconds when establishing the connection via SSH")
-	MainCmd.PersistentFlags().BoolVar(&globalFlags.StrictHostKeyChecking, "strict-host-key-checking", true, "verify host keys presented by remote machines before initiating SSH connections")
-	MainCmd.PersistentFlags().StringVar(&globalFlags.KnownHostsFile, "known-hosts-file", "~/.fleetctl/known_hosts", "file used to store remote machine fingerprints")
+	MainCmd.PersistentFlags().BoolVar(&globalFlags.SSHStrictHostKeyChecking, "ssh-strict-host-key-checking", true, "verify host keys presented by remote machines before initiating SSH connections")
+	MainCmd.PersistentFlags().StringVar(&globalFlags.SSHKnownHostsFile, "ssh-known-hosts-file", "~/.fleetctl/known_hosts", "file used to store remote machine fingerprints")
 
 	MainCmd.AddCommand(submitCmd)
 	MainCmd.AddCommand(statusCmd)

--- a/fleet/fleet_test.go
+++ b/fleet/fleet_test.go
@@ -285,9 +285,9 @@ func Test_Fleet_mapFleetStateToUnitStatusList(t *testing.T) {
 					MachineID:    "",
 					Name:         "name-1",
 					Options: []*schema.UnitOption{
-						{Section:"Unit", Name: "Description", Value: "Test Unit"},
-						{Section:"Service", Name: "ExecStart", Value: "/bin/bash -c 'echo ping'"},
-						{Section:"x-Fleet", Name: "Global", Value: "true"},
+						{Section: "Unit", Name: "Description", Value: "Test Unit"},
+						{Section: "Service", Name: "ExecStart", Value: "/bin/bash -c 'echo ping'"},
+						{Section: "x-Fleet", Name: "Global", Value: "true"},
 					},
 				},
 			},

--- a/fleet/ssh.go
+++ b/fleet/ssh.go
@@ -1,0 +1,50 @@
+package fleet
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/coreos/fleet/ssh"
+)
+
+// SSHTunnel contains the information needed to create a new ssh client
+type SSHTunnel struct {
+	Tunnel                string
+	Username              string
+	Timeout               time.Duration
+	StrictHostKeyChecking bool
+	KnownHostsFile        string
+}
+
+// NewDialFunc returns an http.Dial function which uses the given ssh tunnel as
+// to connect to the endpoint
+func (t *SSHTunnel) NewDialFunc(config Config) func(string, string) (net.Conn, error) {
+	sshClient, err := ssh.NewSSHClient(t.Username, t.Tunnel, t.getChecker(), true, t.Timeout)
+	if err != nil {
+		fmt.Printf("failed to initialize ssh client: %v\n", maskAny(err))
+		os.Exit(1)
+	}
+	tunnelFunc := sshClient.Dial
+
+	if config.Endpoint.Scheme == "unix" || config.Endpoint.Scheme == "file" {
+		tgt := config.Endpoint.Path
+		tunnelFunc = func(string, string) (net.Conn, error) {
+			cmd := fmt.Sprintf(`fleetctl fd-forward %s`, tgt)
+			return ssh.DialCommand(sshClient, cmd)
+		}
+	}
+
+	return tunnelFunc
+}
+
+// getChecker creates and returns a HostKeyChecker, or nil if any error is encountered
+func (t *SSHTunnel) getChecker() *ssh.HostKeyChecker {
+	if !t.StrictHostKeyChecking {
+		return nil
+	}
+
+	keyFile := ssh.NewHostKeyFile(t.KnownHostsFile)
+	return ssh.NewHostKeyChecker(keyFile)
+}

--- a/fleet/ssh.go
+++ b/fleet/ssh.go
@@ -29,9 +29,9 @@ func (t *SSHTunnel) NewDialFunc(config Config) func(string, string) (net.Conn, e
 	tunnelFunc := sshClient.Dial
 
 	if config.Endpoint.Scheme == "unix" || config.Endpoint.Scheme == "file" {
-		tgt := config.Endpoint.Path
+		target := config.Endpoint.Path
 		tunnelFunc = func(string, string) (net.Conn, error) {
-			cmd := fmt.Sprintf(`fleetctl fd-forward %s`, tgt)
+			cmd := fmt.Sprintf(`fleetctl fd-forward %s`, target)
 			return ssh.DialCommand(sshClient, cmd)
 		}
 	}

--- a/int-tests/000-usage.t
+++ b/int-tests/000-usage.t
@@ -17,9 +17,14 @@
     version     Print version
   
   Flags:
-        --fleet-endpoint string   endpoint used to connect to fleet (default "unix:///var/run/fleet.sock")
-    -h, --help                    help for inagoctl
-        --no-block                block on synchronous actions
-    -v, --verbose                 verbose output
+        --fleet-endpoint string      endpoint used to connect to fleet (default "unix:///var/run/fleet.sock")
+    -h, --help                       help for inagoctl
+        --known-hosts-file string    file used to store remote machine fingerprints (default "~/.fleetctl/known_hosts")
+        --no-block                   block on synchronous actions
+        --ssh-timeout duration       timeout in seconds when establishing the connection via SSH (default 10s)
+        --ssh-username string        username to use when connecting to CoreOS machine (default "core")
+        --strict-host-key-checking   verify host keys presented by remote machines before initiating SSH connections (default true)
+        --tunnel string              use a tunnel to communicate with fleet
+    -v, --verbose                    verbose output
   
   Use "inagoctl [command] --help" for more information about a command.

--- a/int-tests/000-usage.t
+++ b/int-tests/000-usage.t
@@ -17,14 +17,14 @@
     version     Print version
   
   Flags:
-        --fleet-endpoint string      endpoint used to connect to fleet (default "unix:///var/run/fleet.sock")
-    -h, --help                       help for inagoctl
-        --known-hosts-file string    file used to store remote machine fingerprints (default "~/.fleetctl/known_hosts")
-        --no-block                   block on synchronous actions
-        --ssh-timeout duration       timeout in seconds when establishing the connection via SSH (default 10s)
-        --ssh-username string        username to use when connecting to CoreOS machine (default "core")
-        --strict-host-key-checking   verify host keys presented by remote machines before initiating SSH connections (default true)
-        --tunnel string              use a tunnel to communicate with fleet
-    -v, --verbose                    verbose output
+        --fleet-endpoint string          endpoint used to connect to fleet (default "unix:///var/run/fleet.sock")
+    -h, --help                           help for inagoctl
+        --no-block                       block on synchronous actions
+        --ssh-known-hosts-file string    file used to store remote machine fingerprints (default "~/.fleetctl/known_hosts")
+        --ssh-strict-host-key-checking   verify host keys presented by remote machines before initiating SSH connections (default true)
+        --ssh-timeout duration           timeout in seconds when establishing the connection via SSH (default 10s)
+        --ssh-username string            username to use when connecting to CoreOS machine (default "core")
+        --tunnel string                  use a tunnel to communicate with fleet
+    -v, --verbose                        verbose output
   
   Use "inagoctl [command] --help" for more information about a command.


### PR DESCRIPTION
This PR adds a `--tunnel` flag, which enables the user to use an ssh tunnel to connect to fleet.
The implementation is based heavily on https://github.com/coreos/fleet/blob/master/fleetctl/fleetctl.go and uses the ssh client in https://github.com/coreos/fleet/blob/master/fleetctl/ssh.go.

fixes #174 

<!---
@huboard:{"custom_state":"archived"}
-->
