### PR TITLE
added commit hash to version output

### DIFF
--- a/cli/version.go
+++ b/cli/version.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	projectBuild   string
 	projectVersion string
 
 	versionCmd = &cobra.Command{
@@ -18,5 +19,5 @@ var (
 )
 
 func versionRun(cmd *cobra.Command, args []string) {
-	fmt.Printf("inagoctl %s\n", projectVersion)
+	fmt.Printf("inagoctl %s (%s)\n", projectVersion, projectBuild)
 }


### PR DESCRIPTION
fixes #208 

This is how it looks like.

```
$ inagoctl version
inagoctl 0.2.0+git (413178c)
```

RFR @JosephSalisbury @Nesurion @zeisss 
