### PR TITLE
Allow removing units if minAlive=0

### DIFF
--- a/controller/update.go
+++ b/controller/update.go
@@ -82,7 +82,7 @@ func (c controller) isGroupRemovalAllowed(ctx context.Context, req Request, minA
 	// if minAlive = 0 we don't need to calculate if we can remove slices,
 	// as the user provided us with the information, that killing slices is fine
 	if (minAlive-int(*removeInProgress)) > 0 || minAlive == 0 {
-		c.Config.Logger.Debug(ctx, "controller: group removal allowed ((minAlive - int(removeInProgress)) > 0)")
+		c.Config.Logger.Debug(ctx, "controller: group removal allowed ((minAlive - int(removeInProgress)) > 0) || minAlive == 0")
 		return true, nil
 	}
 

--- a/controller/update.go
+++ b/controller/update.go
@@ -79,8 +79,9 @@ func (c controller) isGroupRemovalAllowed(ctx context.Context, req Request, minA
 		ctx, "controller: removeInProgress: %v, minAlive: %v",
 		*removeInProgress, minAlive,
 	)
-
-	if (minAlive - int(*removeInProgress)) > 0 {
+	// if minAlive = 0 we don't need to calculate if we can remove slices,
+	// as the user provided us with the information, that killing slices is fine
+	if (minAlive-int(*removeInProgress)) > 0 || minAlive == 0 {
 		c.Config.Logger.Debug(ctx, "controller: group removal allowed ((minAlive - int(removeInProgress)) > 0)")
 		return true, nil
 	}

--- a/controller/update_test.go
+++ b/controller/update_test.go
@@ -177,13 +177,13 @@ func TestIsGroupRemovalAllowed(t *testing.T) {
 		groupRemovalAllowed bool
 		errMatcher          func(err error) bool
 	}{
-		// Test group removal is not allowed if we ask to keep 0 alive,
-		// and fleet has no units in it.
+		// Test group removal is always allowed when the we don't require
+		// any slices to be alive.
 		{
 			req:                 Request{},
 			minAlive:            0,
 			removeInProgress:    0,
-			groupRemovalAllowed: false,
+			groupRemovalAllowed: true,
 			errMatcher:          nil,
 		},
 		// Test group removal is allowed if we ask to keep 1 alive,

--- a/int-tests/006-max-growth-zero-update.t
+++ b/int-tests/006-max-growth-zero-update.t
@@ -1,4 +1,4 @@
-This test checks the behaviourof an update with max-growth zero
+This test checks the behaviour of an update with max-growth zero
 
 Setup unit file
 

--- a/int-tests/007-min-alive-zero-update.t
+++ b/int-tests/007-min-alive-zero-update.t
@@ -18,7 +18,7 @@ Modify unit
 
 Update unit
 
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} update $GROUP --max-growth=0 --min-alive=0 --ready-secs=5
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} update $GROUP --max-growth=0 --min-alive=0 --ready-secs=2
   .*controller: removing units (re)
   .*controller: removing units (re)
   .*controller: adding units (re)

--- a/int-tests/007-min-alive-zero-update.t
+++ b/int-tests/007-min-alive-zero-update.t
@@ -1,4 +1,4 @@
-This test checks the behaviourof an update with max-growth zero
+This test checks the behaviour of an update with max-growth zero
 
 Setup unit file
 

--- a/int-tests/007-min-alive-zero-update.t
+++ b/int-tests/007-min-alive-zero-update.t
@@ -1,0 +1,28 @@
+This test checks the behaviourof an update with max-growth zero
+
+Setup unit file
+
+  $ GROUP=007-min-alive-zero-update
+  $ mkdir $GROUP
+  $ echo "[Unit]\nDescription=Unit 1\n[Service]\nExecStart=/bin/bash -c 'while true; do echo Hello %n; sleep 10; done'\n" > $GROUP/$GROUP-unit@.service
+
+Submit and start group
+
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} submit $GROUP 2 > /dev/null 2>&1
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} start $GROUP > /dev/null 2>&1
+  $ sleep 3
+
+Modify unit
+
+  $ echo "[Unit]\nDescription=Unit 1 (CHANGED)\n[Service]\nExecStart=/bin/bash -c 'while true; do echo Hello %n; sleep 10; done'\n" > $GROUP/$GROUP-unit@.service
+
+Update unit
+
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} update $GROUP --max-growth=0 --min-alive=0
+  .*\|\scontext.Background: Succeeded to update 2 slices for group '007-min-alive-zero-update': \[[a-z0-9]{3} [a-z0-9]{3}\]. (re)
+  $ sleep 3
+
+Tear down
+
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} destroy $GROUP
+  .*\|\scontext.Background: Succeeded to destroy 2 slices for group '007-min-alive-zero-update': \[[a-z0-9]{3} [a-z0-9]{3}\]. (re)

--- a/int-tests/007-min-alive-zero-update.t
+++ b/int-tests/007-min-alive-zero-update.t
@@ -19,6 +19,10 @@ Modify unit
 Update unit
 
   $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} update $GROUP --max-growth=0 --min-alive=0 --ready-secs=5
+  .*controller: removing units (re)
+  .*controller: removing units (re)
+  .*controller: adding units (re)
+  .*controller: adding units (re)
   .*\|\scontext.Background: Succeeded to update 2 slices for group '007-min-alive-zero-update': \[[a-z0-9]{3} [a-z0-9]{3}\]. (re)
   $ sleep 3
 

--- a/int-tests/007-min-alive-zero-update.t
+++ b/int-tests/007-min-alive-zero-update.t
@@ -18,7 +18,7 @@ Modify unit
 
 Update unit
 
-  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} update $GROUP --max-growth=0 --min-alive=0
+  $ inagoctl --fleet-endpoint=${FLEET_ENDPOINT} update $GROUP --max-growth=0 --min-alive=0 --ready-secs=5
   .*\|\scontext.Background: Succeeded to update 2 slices for group '007-min-alive-zero-update': \[[a-z0-9]{3} [a-z0-9]{3}\]. (re)
   $ sleep 3
 


### PR DESCRIPTION
In case the min-alive value is set to 0, we allow removing units.

<!---
@huboard:{"order":1.0728836059570312e-06,"milestone_order":245,"custom_state":""}
-->
