### PR TITLE
fix travis test execution

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ $TEST_SUITE == "unit" ]; then
     make lint


### PR DESCRIPTION
Travis would execute the `ci.sh` script to execute tests and build the bin, but would not maked the process as failed if the tests fail.
This PR fixes that.
