### PR TITLE
Add note about statically compiled kubectl.

### DIFF
--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -46,7 +46,7 @@ And we're done!
 
 ## Testing your Kubernetes cluster
 
-You can check if your cluster is running with [`kubectl`](https://coreos.com/kubernetes/docs/latest/configure-kubectl.html):
+You can check if your cluster is running with [`kubectl`](https://coreos.com/kubernetes/docs/latest/configure-kubectl.html).  If you download the statically compiled version directly from kubernetes you will need to symlink the hosts file into /etc with `sudo ln -s /usr/share/baselayout/hosts /etc/hosts`:
 
 ```
 $ kubectl cluster-info


### PR DESCRIPTION
The kubectl you grab from kubernetes will look in /etc/hosts to resolve
localhost, despite the fact that it lives in /usr/share/baselayout/ on
CoreOS.

For demo purposes a symlink should be suitable.
