### PR TITLE
use dockerized go vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,14 @@ test: $(SOURCE) VERSION .gobuild
 	    $(TEST_COMMAND)
 
 lint:
-	go vet -x ./...
+	docker run \
+	    --rm \
+	    -t \
+	    -v $(shell pwd):/usr/code \
+	    -e GOPATH=/usr/code/.gobuild \
+	    -w /usr/code \
+	    golang:$(GOVERSION) \
+	    go vet -x ./...
 	golint ./...
 
 ci-build: $(SOURCE) VERSION .gobuild

--- a/cli/inagoctl.go
+++ b/cli/inagoctl.go
@@ -46,7 +46,7 @@ var (
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			// This callback is executed after flags are parsed and before any
 			// command runs.
-			fs = afero.Afero{afero.NewOsFs()}
+			fs = afero.Afero{Fs: afero.NewOsFs()}
 
 			loggingConfig := logging.DefaultConfig()
 			if globalFlags.Verbose {


### PR DESCRIPTION
Somehow my local version of Go doesn't detect _cli/inagoctl.go:49: afero.Afero composite literal uses unkeyed fields_. Using dockerized linter would cause less CI failures/fixes when used with pre commit hook.

```
~/g/s/g/g/inago ❯❯❯ go version
go version go1.7 darwin/amd64

~/g/s/g/g/inago ❯❯❯ go vet -x ./...
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/vet main.go
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/vet cli/common.go cli/destroy.go cli/error.go cli/inagoctl.go cli/request.go cli/start.go cli/status.go cli/stop.go cli/submit.go cli/up.go cli/update.go cli/validate.go cli/version.go cli/common_test.go cli/request_test.go cli/submit_test.go
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/vet common/common.go common/error.go common/common_test.go
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/vet controller/controller.go controller/error.go controller/id.go controller/request.go controller/status.go controller/update.go controller/validator.go controller/controller_test.go controller/error_test.go controller/fleet_mock_test.go controller/request_test.go controller/status_test.go controller/update_test.go controller/validator_test.go
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/vet fleet/dummy.go fleet/error.go fleet/fleet.go fleet/ssh.go fleet/dummy_test.go fleet/error_test.go fleet/fleet_client_mock_test.go fleet/fleet_test.go
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/vet logging/go_logging_logger.go logging/logging.go
/usr/local/opt/go/libexec/pkg/tool/darwin_amd64/vet task/error.go task/memory_storage.go task/status.go task/storage.go task/task.go task/task_service.go task/memory_storage_test.go task/status_test.go task/task_service_test.go

~/g/s/g/g/inago ❯❯❯ make lint
docker run \
            --rm \
            -t \
            -v /Users/pawel/go/src/github.com/giantswarm/inago:/usr/code \
            -e GOPATH=/usr/code/.gobuild \
            -w /usr/code \
            golang:1.6.1 \
            go vet -x ./...
/usr/local/go/pkg/tool/linux_amd64/vet main.go
/usr/local/go/pkg/tool/linux_amd64/vet cli/common.go cli/destroy.go cli/error.go cli/inagoctl.go cli/request.go cli/start.go cli/status.go cli/stop.go cli/submit.go cli/up.go cli/update.go cli/validate.go cli/version.go cli/common_test.go cli/request_test.go cli/submit_test.go
cli/inagoctl.go:49: afero.Afero composite literal uses unkeyed fields
exit status 1
/usr/local/go/pkg/tool/linux_amd64/vet common/common.go common/error.go common/common_test.go
/usr/local/go/pkg/tool/linux_amd64/vet controller/controller.go controller/error.go controller/id.go controller/request.go controller/status.go controller/update.go controller/validator.go controller/controller_test.go controller/error_test.go controller/fleet_mock_test.go controller/request_test.go controller/status_test.go controller/update_test.go controller/validator_test.go
/usr/local/go/pkg/tool/linux_amd64/vet fleet/dummy.go fleet/error.go fleet/fleet.go fleet/ssh.go fleet/dummy_test.go fleet/error_test.go fleet/fleet_client_mock_test.go fleet/fleet_test.go
/usr/local/go/pkg/tool/linux_amd64/vet logging/go_logging_logger.go logging/logging.go
/usr/local/go/pkg/tool/linux_amd64/vet task/error.go task/memory_storage.go task/status.go task/storage.go task/task.go task/task_service.go task/memory_storage_test.go task/status_test.go task/task_service_test.go
make: *** [lint] Error 1
```
